### PR TITLE
chore: update feedproviders.yml example

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Mobility aggregation service based on the [General Bikeshare Feed Specification 
                 operatorName: My operator
                 codespace: MFM
                 url: https://myfavoritegbfsfeeed.com/gbfs.json
-                language: en             
-                
+                language: en
+
 This will use the GBFS auto-discovery at `url` and poll `en` language feeds.
 
 NOTE: codespace is relevant when aggregating entities across systems, to avoid conflicts between IDs. 


### PR DESCRIPTION
This PR fixes #152.

It provides an updated feedproviders.yml example and a few hints regarding `codespace` and `operatorId`