### PR TITLE
Dynamic feed availability

### DIFF
--- a/src/main/java/org/entur/lamassu/controller/GBFSFeedController.java
+++ b/src/main/java/org/entur/lamassu/controller/GBFSFeedController.java
@@ -8,6 +8,7 @@ import org.entur.lamassu.cache.GBFSFeedCache;
 import org.entur.lamassu.model.discovery.System;
 import org.entur.lamassu.model.discovery.SystemDiscovery;
 import org.entur.lamassu.model.provider.FeedProvider;
+import org.entur.lamassu.service.FeedAvailabilityService;
 import org.entur.lamassu.service.FeedProviderService;
 import org.entur.lamassu.service.SystemDiscoveryService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,6 +29,8 @@ public class GBFSFeedController {
     private final GBFSFeedCache feedCache;
     private final FeedProviderService feedProviderService;
 
+    private final FeedAvailabilityService feedAvailabilityService;
+
     @Value("${org.entur.lamassu.baseUrl}")
     private String baseUrl;
 
@@ -35,10 +38,11 @@ public class GBFSFeedController {
     private String internalLoadBalancer;
 
     @Autowired
-    public GBFSFeedController(SystemDiscoveryService systemDiscoveryService, GBFSFeedCache feedCache, FeedProviderService feedProviderService) {
+    public GBFSFeedController(SystemDiscoveryService systemDiscoveryService, GBFSFeedCache feedCache, FeedProviderService feedProviderService, FeedAvailabilityService feedAvailabilityService) {
         this.systemDiscoveryService = systemDiscoveryService;
         this.feedCache = feedCache;
         this.feedProviderService = feedProviderService;
+        this.feedAvailabilityService = feedAvailabilityService;
     }
 
     @GetMapping("/gbfs")
@@ -72,8 +76,9 @@ public class GBFSFeedController {
         try {
             var feedName = GBFSFeedName.fromValue(feed);
             var feedProvider = feedProviderService.getFeedProviderBySystemId(systemId);
+            var availableFiles = feedAvailabilityService.getAvailableFiles(systemId);
 
-            if (feedProvider == null) {
+            if (feedProvider == null || availableFiles == null || !availableFiles.contains(feedName) && !feedName.equals(GBFSFeedName.GBFS)) {
                 throw new NoSuchElementException();
             }
 

--- a/src/main/java/org/entur/lamassu/mapper/feedmapper/DiscoveryFeedPostProcessor.java
+++ b/src/main/java/org/entur/lamassu/mapper/feedmapper/DiscoveryFeedPostProcessor.java
@@ -1,0 +1,62 @@
+/*
+ *
+ *
+ *  * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ *  * the European Commission - subsequent versions of the EUPL (the "Licence");
+ *  * You may not use this work except in compliance with the Licence.
+ *  * You may obtain a copy of the Licence at:
+ *  *
+ *  *   https://joinup.ec.europa.eu/software/page/eupl
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the Licence is distributed on an "AS IS" basis,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the Licence for the specific language governing permissions and
+ *  * limitations under the Licence.
+ *
+ */
+
+package org.entur.lamassu.mapper.feedmapper;
+
+import org.entur.gbfs.GbfsDelivery;
+import org.entur.gbfs.v2_3.gbfs.GBFS;
+
+import java.util.stream.Collectors;
+
+public class DiscoveryFeedPostProcessor {
+    public static void removeUnavailableFiles(GBFS discovery, GbfsDelivery mapped) {
+        discovery.getFeedsData().keySet().forEach(language -> {
+            var feeds = discovery.getFeedsData().get(language).getFeeds().stream().filter(feed -> {
+                switch (feed.getName()) {
+                    case SystemInformation:
+                        return mapped.getSystemInformation() != null;
+                    case VehicleTypes:
+                        return mapped.getVehicleTypes() != null;
+                    case FreeBikeStatus:
+                        return mapped.getFreeBikeStatus() != null;
+                    case StationInformation:
+                        return mapped.getStationInformation() != null;
+                    case StationStatus:
+                        return mapped.getStationStatus() != null;
+                    case SystemPricingPlans:
+                        return mapped.getSystemPricingPlans() != null;
+                    case SystemAlerts:
+                        return mapped.getSystemAlerts() != null;
+                    case SystemHours:
+                        return mapped.getSystemHours() !=  null;
+                    case SystemCalendar:
+                        return mapped.getSystemCalendar() != null;
+                    case SystemRegions:
+                        return mapped.getSystemRegions() != null;
+                    case GeofencingZones:
+                        return mapped.getGeofencingZones() != null;
+                    default:
+                        return false;
+                }
+            }).collect(Collectors.toList());
+            discovery.getFeedsData().get(language).setFeeds(feeds);
+        });
+
+
+    }
+}

--- a/src/main/java/org/entur/lamassu/mapper/feedmapper/GbfsDeliveryMapper.java
+++ b/src/main/java/org/entur/lamassu/mapper/feedmapper/GbfsDeliveryMapper.java
@@ -82,7 +82,6 @@ public class GbfsDeliveryMapper {
     // mapping of the versions file, if it exists, is intentionally skipped.
     public GbfsDelivery mapGbfsDelivery(GbfsDelivery delivery, FeedProvider feedProvider) {
         var mapped = new GbfsDelivery();
-        mapped.setDiscovery(discoveryFeedMapper.map(delivery.getDiscovery(), feedProvider));
         mapped.setSystemInformation(systemInformationFeedMapper.map(delivery.getSystemInformation(), feedProvider));
         mapped.setSystemAlerts(systemAlertsFeedMapper.map(delivery.getSystemAlerts(), feedProvider));
         mapped.setSystemCalendar(systemCalendarFeedMapper.map(delivery.getSystemCalendar(), feedProvider));
@@ -99,6 +98,11 @@ public class GbfsDeliveryMapper {
                         stationStatus -> VehicleTypeCapacityProducer.addToStations(stationStatus, mapped.getVehicleTypes()))
         );
         mapped.setFreeBikeStatus(freeBikeStatusFeedMapper.map(delivery.getFreeBikeStatus(), feedProvider));
+        mapped.setDiscovery(
+                discoveryFeedMapper.map(
+                        delivery.getDiscovery(),
+                        feedProvider,
+                        discovery -> DiscoveryFeedPostProcessor.removeUnavailableFiles(discovery, mapped)));
         return mapped;
     }
 }

--- a/src/main/java/org/entur/lamassu/service/FeedAvailabilityService.java
+++ b/src/main/java/org/entur/lamassu/service/FeedAvailabilityService.java
@@ -1,0 +1,30 @@
+/*
+ *
+ *
+ *  * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ *  * the European Commission - subsequent versions of the EUPL (the "Licence");
+ *  * You may not use this work except in compliance with the Licence.
+ *  * You may obtain a copy of the Licence at:
+ *  *
+ *  *   https://joinup.ec.europa.eu/software/page/eupl
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the Licence is distributed on an "AS IS" basis,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the Licence for the specific language governing permissions and
+ *  * limitations under the Licence.
+ *
+ */
+
+package org.entur.lamassu.service;
+
+import org.entur.gbfs.v2_3.gbfs.GBFSFeedName;
+
+import java.util.List;
+import java.util.Map;
+
+public interface FeedAvailabilityService {
+    Map<String, List<GBFSFeedName>> getAvailableFeeds();
+    List<GBFSFeedName> getAvailableFiles(String systemId);
+    void setAvailableFiles(String systemId, List<GBFSFeedName> files);
+}

--- a/src/main/java/org/entur/lamassu/service/impl/MockFeedAvailabilityService.java
+++ b/src/main/java/org/entur/lamassu/service/impl/MockFeedAvailabilityService.java
@@ -1,0 +1,59 @@
+/*
+ *
+ *
+ *  * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ *  * the European Commission - subsequent versions of the EUPL (the "Licence");
+ *  * You may not use this work except in compliance with the Licence.
+ *  * You may obtain a copy of the Licence at:
+ *  *
+ *  *   https://joinup.ec.europa.eu/software/page/eupl
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the Licence is distributed on an "AS IS" basis,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the Licence for the specific language governing permissions and
+ *  * limitations under the Licence.
+ *
+ */
+
+package org.entur.lamassu.service.impl;
+
+import org.entur.gbfs.v2_3.gbfs.GBFSFeedName;
+import org.entur.lamassu.service.FeedAvailabilityService;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * This mock service is only to demonstrate functionality. A service based on redis should be implemented
+ * before merging.
+ */
+@Component
+public class MockFeedAvailabilityService implements FeedAvailabilityService {
+    private final ConcurrentHashMap<String, List<GBFSFeedName>> availableFilesPerSystem = new ConcurrentHashMap<>();
+
+    @Override
+    public Map<String, List<GBFSFeedName>> getAvailableFeeds() {
+        return availableFilesPerSystem;
+    }
+
+    @Override
+    public List<GBFSFeedName> getAvailableFiles(String systemId) {
+        return availableFilesPerSystem.get(systemId);
+    }
+
+    @Override
+    public void setAvailableFiles(String systemId, List<GBFSFeedName> files) {
+        var minimumRequired = files.containsAll(List.of(GBFSFeedName.SystemInformation, GBFSFeedName.VehicleTypes, GBFSFeedName.SystemPricingPlans));
+        var freeFloating = files.contains(GBFSFeedName.FreeBikeStatus);
+        var stationBased = files.containsAll(List.of(GBFSFeedName.StationInformation, GBFSFeedName.StationStatus));
+
+        if (minimumRequired && (freeFloating || stationBased)) {
+            availableFilesPerSystem.put(systemId, files);
+        } else {
+            availableFilesPerSystem.remove(systemId);
+        }
+    }
+}

--- a/src/main/java/org/entur/lamassu/service/impl/SystemDiscoveryServiceImpl.java
+++ b/src/main/java/org/entur/lamassu/service/impl/SystemDiscoveryServiceImpl.java
@@ -2,6 +2,7 @@ package org.entur.lamassu.service.impl;
 
 import org.entur.lamassu.mapper.entitymapper.SystemDiscoveryMapper;
 import org.entur.lamassu.model.discovery.SystemDiscovery;
+import org.entur.lamassu.service.FeedAvailabilityService;
 import org.entur.lamassu.service.FeedProviderService;
 import org.entur.lamassu.service.SystemDiscoveryService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,19 +12,27 @@ import java.util.stream.Collectors;
 
 @Component
 public class SystemDiscoveryServiceImpl implements SystemDiscoveryService {
-    private final SystemDiscovery systemDiscovery;
+
+    private final FeedProviderService feedProviderService;
+    private final FeedAvailabilityService feedAvailabilityService;
+    private final SystemDiscoveryMapper systemDiscoveryMapper;
 
     @Autowired
-    public SystemDiscoveryServiceImpl(FeedProviderService feedProviderService, SystemDiscoveryMapper systemDiscoveryMapper) {
-        systemDiscovery = new SystemDiscovery();
-        systemDiscovery.setSystems(
-                feedProviderService.getFeedProviders().stream()
-                        .map(systemDiscoveryMapper::mapSystemDiscovery).collect(Collectors.toList())
-        );
+    public SystemDiscoveryServiceImpl(FeedProviderService feedProviderService, FeedAvailabilityService feedAvailabilityService, SystemDiscoveryMapper systemDiscoveryMapper) {
+        this.feedProviderService = feedProviderService;
+        this.feedAvailabilityService = feedAvailabilityService;
+        this.systemDiscoveryMapper = systemDiscoveryMapper;
     }
 
     @Override
     public SystemDiscovery getSystemDiscovery() {
+        var systemDiscovery = new SystemDiscovery();
+        systemDiscovery.setSystems(
+                feedAvailabilityService.getAvailableFeeds().keySet().stream()
+                        .map(feedProviderService::getFeedProviderBySystemId)
+                        .map(systemDiscoveryMapper::mapSystemDiscovery)
+                        .collect(Collectors.toList())
+        );
         return systemDiscovery;
     }
 }


### PR DESCRIPTION
The api should not link to unavailable content.

* The system discovery file should not link to urls that give 404
* Each gbfs discovery file should not link to files that give 404
* A gbfs file endpoint should be able to 404 even if it is available in the cache (? is it necessary)

This requires that the discovery endpoints content is populated dynamically based on available / mapped data continously.