### PR TITLE
Use vehicle id as cache key in vehicle cache

### DIFF
--- a/src/main/java/org/entur/lamassu/leader/listener/delegates/VehicleListenerDelegate.java
+++ b/src/main/java/org/entur/lamassu/leader/listener/delegates/VehicleListenerDelegate.java
@@ -22,35 +22,29 @@ import org.entur.lamassu.cache.VehicleSpatialIndex;
 import org.entur.lamassu.leader.listener.CacheEntryListenerDelegate;
 import org.entur.lamassu.model.entities.Vehicle;
 import org.entur.lamassu.service.FeedProviderService;
-import org.entur.lamassu.util.SpatialIndexIdUtil;
 import org.redisson.api.map.event.EntryEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.util.Set;
 import java.util.stream.Collectors;
 
 @Component
 public class VehicleListenerDelegate implements CacheEntryListenerDelegate<Vehicle> {
-    private final FeedProviderService feedProviderService;
     private final VehicleSpatialIndex spatialIndex;
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     @Autowired
     public VehicleListenerDelegate(
-            FeedProviderService feedProviderService,
             VehicleSpatialIndex spatialIndex
     ) {
-        this.feedProviderService = feedProviderService;
         this.spatialIndex = spatialIndex;
     }
 
     @Override
     public void onExpired(EntryEvent<String, Vehicle> event) {
         logger.info("Expired event {}", event);
-        var name = event.getKey();
         var vehicle= event.getValue();
         var expired = spatialIndex.getAll().stream()
                 .filter(spatialIndexId -> spatialIndexId.getId().equals(vehicle.getId()))

--- a/src/main/java/org/entur/lamassu/leader/listener/delegates/VehicleListenerDelegate.java
+++ b/src/main/java/org/entur/lamassu/leader/listener/delegates/VehicleListenerDelegate.java
@@ -30,6 +30,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @Component
 public class VehicleListenerDelegate implements CacheEntryListenerDelegate<Vehicle> {
@@ -51,16 +52,9 @@ public class VehicleListenerDelegate implements CacheEntryListenerDelegate<Vehic
         logger.info("Expired event {}", event);
         var name = event.getKey();
         var vehicle= event.getValue();
-        var split = name.split("_");
-        var feedProvider = feedProviderService.getFeedProviderBySystemId(split[split.length - 1]);
-        if (feedProvider == null) {
-            logger.warn("Feed provider not found on expired vehicle={}. Probably means feed provider was removed.", name);
-        } else {
-            var id = SpatialIndexIdUtil.createVehicleSpatialIndexId(
-                    vehicle,
-                    feedProvider
-            );
-            spatialIndex.removeAll(Set.of(id));
-        }
+        var expired = spatialIndex.getAll().stream()
+                .filter(spatialIndexId -> spatialIndexId.getId().equals(vehicle.getId()))
+                .collect(Collectors.toSet());
+        spatialIndex.removeAll(expired);
     }
 }

--- a/src/main/java/org/entur/lamassu/leader/listener/delegates/VehicleListenerDelegate.java
+++ b/src/main/java/org/entur/lamassu/leader/listener/delegates/VehicleListenerDelegate.java
@@ -21,7 +21,6 @@ package org.entur.lamassu.leader.listener.delegates;
 import org.entur.lamassu.cache.VehicleSpatialIndex;
 import org.entur.lamassu.leader.listener.CacheEntryListenerDelegate;
 import org.entur.lamassu.model.entities.Vehicle;
-import org.entur.lamassu.service.FeedProviderService;
 import org.redisson.api.map.event.EntryEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/org/entur/lamassu/service/impl/GeoSearchServiceImpl.java
+++ b/src/main/java/org/entur/lamassu/service/impl/GeoSearchServiceImpl.java
@@ -1,6 +1,5 @@
 package org.entur.lamassu.service.impl;
 
-import org.entur.lamassu.cache.AbstractSpatialIndexId;
 import org.entur.lamassu.cache.StationCache;
 import org.entur.lamassu.cache.StationSpatialIndex;
 import org.entur.lamassu.cache.StationSpatialIndexId;
@@ -9,10 +8,10 @@ import org.entur.lamassu.cache.VehicleSpatialIndex;
 import org.entur.lamassu.cache.VehicleSpatialIndexId;
 import org.entur.lamassu.model.entities.Station;
 import org.entur.lamassu.model.entities.Vehicle;
+import org.entur.lamassu.service.GeoSearchService;
+import org.entur.lamassu.service.RangeQueryParameters;
 import org.entur.lamassu.service.StationFilterParameters;
 import org.entur.lamassu.service.VehicleFilterParameters;
-import org.entur.lamassu.service.RangeQueryParameters;
-import org.entur.lamassu.service.GeoSearchService;
 import org.entur.lamassu.util.SpatialIndexIdFilter;
 import org.redisson.api.GeoOrder;
 import org.redisson.api.GeoUnit;
@@ -24,7 +23,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @Component
 public class GeoSearchServiceImpl implements GeoSearchService {

--- a/src/main/java/org/entur/lamassu/service/impl/GeoSearchServiceImpl.java
+++ b/src/main/java/org/entur/lamassu/service/impl/GeoSearchServiceImpl.java
@@ -57,7 +57,7 @@ public class GeoSearchServiceImpl implements GeoSearchService {
             stream = stream.limit(count.longValue());
         }
 
-        Set<String> vehicleIds = stream.map(this::getVehicleCacheKey)
+        Set<String> vehicleIds = stream.map(VehicleSpatialIndexId::getId)
                 .collect(Collectors.toSet());
 
         return vehicleCache.getAll(vehicleIds);
@@ -94,7 +94,7 @@ public class GeoSearchServiceImpl implements GeoSearchService {
         var indexIds = vehicleSpatialIndex.getAll();
         return indexIds.stream()
                 .filter(Objects::nonNull)
-                .map(this::getVehicleCacheKey)
+                .map(VehicleSpatialIndexId::getId)
                 .filter(key -> !vehicleCache.hasKey(key))
                 .collect(Collectors.toList());
     }
@@ -104,14 +104,11 @@ public class GeoSearchServiceImpl implements GeoSearchService {
         var indexIds = vehicleSpatialIndex.getAll();
         var orphans = indexIds.stream()
                 .filter(Objects::nonNull)
-                .filter(indexId -> {
-                    var cacheKey = getVehicleCacheKey(indexId);
-                    return !vehicleCache.hasKey(cacheKey);
-                })
+                .filter(indexId -> !vehicleCache.hasKey(indexId.getId()))
                 .collect(Collectors.toSet());
 
         vehicleSpatialIndex.removeAll(orphans);
 
-        return orphans.stream().map(this::getVehicleCacheKey).collect(Collectors.toList());
+        return orphans.stream().map(VehicleSpatialIndexId::getId).collect(Collectors.toList());
     }
 }

--- a/src/main/java/org/entur/lamassu/service/impl/GeoSearchServiceImpl.java
+++ b/src/main/java/org/entur/lamassu/service/impl/GeoSearchServiceImpl.java
@@ -63,10 +63,6 @@ public class GeoSearchServiceImpl implements GeoSearchService {
         return vehicleCache.getAll(vehicleIds);
     }
 
-    private String getVehicleCacheKey(VehicleSpatialIndexId spatialIndexId) {
-        return spatialIndexId.getId() + "_" + spatialIndexId.getSystemId();
-    }
-
     @Override
     public List<Station> getStationsNearby(RangeQueryParameters rangeQueryParameters, StationFilterParameters filterParameters) {
         Double longitude = rangeQueryParameters.getLon();

--- a/src/main/java/org/entur/lamassu/service/impl/GeoSearchServiceImpl.java
+++ b/src/main/java/org/entur/lamassu/service/impl/GeoSearchServiceImpl.java
@@ -1,5 +1,6 @@
 package org.entur.lamassu.service.impl;
 
+import org.entur.lamassu.cache.AbstractSpatialIndexId;
 import org.entur.lamassu.cache.StationCache;
 import org.entur.lamassu.cache.StationSpatialIndex;
 import org.entur.lamassu.cache.StationSpatialIndexId;
@@ -23,6 +24,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Component
 public class GeoSearchServiceImpl implements GeoSearchService {

--- a/src/test/java/org/entur/lamassu/leader/listener/delegates/VehicleListenerDelegateTest.java
+++ b/src/test/java/org/entur/lamassu/leader/listener/delegates/VehicleListenerDelegateTest.java
@@ -25,7 +25,6 @@ import org.entur.lamassu.model.entities.PropulsionType;
 import org.entur.lamassu.model.entities.Vehicle;
 import org.entur.lamassu.model.entities.VehicleType;
 import org.entur.lamassu.model.provider.FeedProvider;
-import org.entur.lamassu.service.FeedProviderService;
 import org.entur.lamassu.util.SpatialIndexIdUtil;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -38,8 +37,6 @@ import static org.mockito.Mockito.when;
 
 class VehicleListenerDelegateTest {
     VehicleSpatialIndex mockIndex = Mockito.mock(VehicleSpatialIndex.class);
-    FeedProviderService mockFeedProviderService = Mockito.mock(FeedProviderService.class);
-
 
     @Test
     void testExpiry() {
@@ -47,12 +44,11 @@ class VehicleListenerDelegateTest {
         Vehicle vehicle = getVehicle();
         VehicleSpatialIndexId expectedId = SpatialIndexIdUtil.createVehicleSpatialIndexId(vehicle, feedProvider);
 
-        when(mockFeedProviderService.getFeedProviderBySystemId(feedProvider.getSystemId())).thenReturn(feedProvider);
         when(mockIndex.getAll()).thenReturn(List.of(expectedId));
 
         EntryEvent<String, Vehicle> event = new EntryEvent<>(null, EntryEvent.Type.EXPIRED, "foo", vehicle, null);
 
-        var subject = new VehicleListenerDelegate(mockFeedProviderService, mockIndex);
+        var subject = new VehicleListenerDelegate(mockIndex);
         subject.onExpired(event);
 
         Mockito.verify(mockIndex).removeAll(Set.of(expectedId));

--- a/src/test/java/org/entur/lamassu/leader/listener/delegates/VehicleListenerDelegateTest.java
+++ b/src/test/java/org/entur/lamassu/leader/listener/delegates/VehicleListenerDelegateTest.java
@@ -19,6 +19,7 @@
 package org.entur.lamassu.leader.listener.delegates;
 
 import org.entur.lamassu.cache.VehicleSpatialIndex;
+import org.entur.lamassu.cache.VehicleSpatialIndexId;
 import org.entur.lamassu.model.entities.FormFactor;
 import org.entur.lamassu.model.entities.PropulsionType;
 import org.entur.lamassu.model.entities.Vehicle;
@@ -30,6 +31,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.redisson.api.map.event.EntryEvent;
 
+import java.util.List;
 import java.util.Set;
 
 import static org.mockito.Mockito.when;
@@ -43,15 +45,16 @@ class VehicleListenerDelegateTest {
     void testExpiry() {
         FeedProvider feedProvider = getFeedProvider();
         Vehicle vehicle = getVehicle();
+        VehicleSpatialIndexId expectedId = SpatialIndexIdUtil.createVehicleSpatialIndexId(vehicle, feedProvider);
 
         when(mockFeedProviderService.getFeedProviderBySystemId(feedProvider.getSystemId())).thenReturn(feedProvider);
+        when(mockIndex.getAll()).thenReturn(List.of(expectedId));
 
         EntryEvent<String, Vehicle> event = new EntryEvent<>(null, EntryEvent.Type.EXPIRED, "foo", vehicle, null);
 
         var subject = new VehicleListenerDelegate(mockFeedProviderService, mockIndex);
         subject.onExpired(event);
 
-        var expectedId = SpatialIndexIdUtil.createVehicleSpatialIndexId(vehicle, feedProvider);
         Mockito.verify(mockIndex).removeAll(Set.of(expectedId));
 
     }

--- a/src/test/java/org/entur/lamassu/leader/listener/delegates/VehicleListenerDelegateTest.java
+++ b/src/test/java/org/entur/lamassu/leader/listener/delegates/VehicleListenerDelegateTest.java
@@ -46,7 +46,7 @@ class VehicleListenerDelegateTest {
 
         when(mockFeedProviderService.getFeedProviderBySystemId(feedProvider.getSystemId())).thenReturn(feedProvider);
 
-        EntryEvent<String, Vehicle> event = new EntryEvent<>(null, EntryEvent.Type.EXPIRED, "foo_bar", vehicle, null);
+        EntryEvent<String, Vehicle> event = new EntryEvent<>(null, EntryEvent.Type.EXPIRED, "foo", vehicle, null);
 
         var subject = new VehicleListenerDelegate(mockFeedProviderService, mockIndex);
         subject.onExpired(event);

--- a/src/test/java/org/entur/lamassu/service/GeoSearchServiceTest.java
+++ b/src/test/java/org/entur/lamassu/service/GeoSearchServiceTest.java
@@ -1,0 +1,141 @@
+/*
+ *
+ *
+ *  * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ *  * the European Commission - subsequent versions of the EUPL (the "Licence");
+ *  * You may not use this work except in compliance with the Licence.
+ *  * You may obtain a copy of the Licence at:
+ *  *
+ *  *   https://joinup.ec.europa.eu/software/page/eupl
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the Licence is distributed on an "AS IS" basis,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the Licence for the specific language governing permissions and
+ *  * limitations under the Licence.
+ *
+ */
+
+/*
+ *
+ *
+ *  * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ *  * the European Commission - subsequent versions of the EUPL (the "Licence");
+ *  * You may not use this work except in compliance with the Licence.
+ *  * You may obtain a copy of the Licence at:
+ *  *
+ *  *   https://joinup.ec.europa.eu/software/page/eupl
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the Licence is distributed on an "AS IS" basis,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the Licence for the specific language governing permissions and
+ *  * limitations under the Licence.
+ *
+ */
+
+package org.entur.lamassu.service;
+
+import org.entur.lamassu.cache.StationCache;
+import org.entur.lamassu.cache.StationSpatialIndex;
+import org.entur.lamassu.cache.VehicleCache;
+import org.entur.lamassu.cache.VehicleSpatialIndex;
+import org.entur.lamassu.model.entities.FormFactor;
+import org.entur.lamassu.model.entities.PropulsionType;
+import org.entur.lamassu.model.entities.Vehicle;
+import org.entur.lamassu.model.entities.VehicleType;
+import org.entur.lamassu.model.provider.FeedProvider;
+import org.entur.lamassu.service.impl.GeoSearchServiceImpl;
+import org.entur.lamassu.stubs.VehicleCacheStub;
+import org.entur.lamassu.util.SpatialIndexIdUtil;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+
+import java.util.ArrayList;
+import java.util.PrimitiveIterator;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class GeoSearchServiceTest {
+
+    private final VehicleSpatialIndex vehicleSpatialIndex = mock(VehicleSpatialIndex.class);
+    private final StationSpatialIndex stationSpatialIndex = mock(StationSpatialIndex.class);
+    private final VehicleCache vehicleCache = new VehicleCacheStub();
+    private final StationCache stationCache = mock(StationCache.class);
+    private final FeedProvider feedProvider = getFeedProvider();
+    private final GeoSearchService service = new GeoSearchServiceImpl(
+        vehicleSpatialIndex,
+        stationSpatialIndex,
+        vehicleCache,
+        stationCache
+    );
+
+    @Before
+    public void setup() {
+        var vehicles = new ArrayList<Vehicle>();
+
+        for (PrimitiveIterator.OfInt it = IntStream.range(0, 10).iterator(); it.hasNext(); ) {
+            vehicles.add(getVehicle(it.next()));
+        }
+
+        vehicleCache.updateAll(vehicles.stream().collect(Collectors.toMap(Vehicle::getId, v -> v)), 0, TimeUnit.SECONDS);
+
+        when(vehicleSpatialIndex.getAll()).thenReturn(
+                vehicles.stream()
+                        .map(vehicle -> SpatialIndexIdUtil.createVehicleSpatialIndexId(vehicle, feedProvider))
+                        .collect(Collectors.toList())
+        );
+    }
+
+    @Test
+    public void sanityCheck() {
+        Assertions.assertTrue(vehicleCache.hasKey("foo_1"));
+    }
+
+    @Test
+    public void testGetVehicleOrphansIsEmpty() {
+        var orphans = service.getVehicleSpatialIndexOrphans();
+        Assertions.assertTrue(orphans.isEmpty());
+    }
+
+    @Test
+    public void testGetVehicleOrphansReturnsOrphanWhenRemovingVehicleFromCache() {
+        vehicleCache.removeAll(Set.of("foo_1"));
+        var orphans = service.getVehicleSpatialIndexOrphans();
+        Assertions.assertEquals(1, orphans.size());
+        Assertions.assertTrue(orphans.contains("foo_1"));
+    }
+
+    @Test
+    public void testRemoveVehicleSpatialIndexOrphans() {
+        var vehicleToRemove = vehicleCache.get("foo_1");
+        vehicleCache.removeAll(Set.of("foo_1"));
+        var orphans = service.removeVehicleSpatialIndexOrphans();
+        verify(vehicleSpatialIndex).removeAll(Set.of(SpatialIndexIdUtil.createVehicleSpatialIndexId(vehicleToRemove, feedProvider)));
+    }
+
+    private Vehicle getVehicle(int i) {
+        var vehicle = new Vehicle();
+        vehicle.setId("foo_" + i);
+        var vehicleType = new VehicleType();
+        vehicleType.setFormFactor(FormFactor.SCOOTER);
+        vehicleType.setPropulsionType(PropulsionType.ELECTRIC);
+        vehicle.setVehicleType(vehicleType);
+        vehicle.setReserved(false);
+        vehicle.setDisabled(false);
+        return vehicle;
+    }
+
+    private FeedProvider getFeedProvider() {
+        var feedProvider = new FeedProvider();
+        feedProvider.setSystemId("bar");
+        return feedProvider;
+    }
+}

--- a/src/test/java/org/entur/lamassu/service/GeoSearchServiceTest.java
+++ b/src/test/java/org/entur/lamassu/service/GeoSearchServiceTest.java
@@ -16,24 +16,6 @@
  *
  */
 
-/*
- *
- *
- *  * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
- *  * the European Commission - subsequent versions of the EUPL (the "Licence");
- *  * You may not use this work except in compliance with the Licence.
- *  * You may obtain a copy of the Licence at:
- *  *
- *  *   https://joinup.ec.europa.eu/software/page/eupl
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the Licence is distributed on an "AS IS" basis,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the Licence for the specific language governing permissions and
- *  * limitations under the Licence.
- *
- */
-
 package org.entur.lamassu.service;
 
 import org.entur.lamassu.cache.StationCache;

--- a/src/test/java/org/entur/lamassu/stubs/VehicleCacheStub.java
+++ b/src/test/java/org/entur/lamassu/stubs/VehicleCacheStub.java
@@ -1,0 +1,67 @@
+/*
+ *
+ *
+ *  * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ *  * the European Commission - subsequent versions of the EUPL (the "Licence");
+ *  * You may not use this work except in compliance with the Licence.
+ *  * You may obtain a copy of the Licence at:
+ *  *
+ *  *   https://joinup.ec.europa.eu/software/page/eupl
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the Licence is distributed on an "AS IS" basis,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the Licence for the specific language governing permissions and
+ *  * limitations under the Licence.
+ *
+ */
+
+package org.entur.lamassu.stubs;
+
+import org.entur.lamassu.cache.VehicleCache;
+import org.entur.lamassu.model.entities.Vehicle;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+public class VehicleCacheStub implements VehicleCache {
+    private final Map<String, Vehicle> map = new HashMap<>();
+
+    @Override
+    public List<Vehicle> getAll(Set<String> keys) {
+        return null;
+    }
+
+    @Override
+    public List<Vehicle> getAll() {
+        return null;
+    }
+
+    @Override
+    public Map<String, Vehicle> getAllAsMap(Set<String> keys) {
+        return null;
+    }
+
+    @Override
+    public Vehicle get(String key) {
+        return map.get(key);
+    }
+
+    @Override
+    public void updateAll(Map<String, Vehicle> entities, int ttl, TimeUnit timeUnit) {
+        map.putAll(entities);
+    }
+
+    @Override
+    public void removeAll(Set<String> keys) {
+        keys.forEach(map::remove);
+    }
+
+    @Override
+    public boolean hasKey(String key) {
+        return map.containsKey(key);
+    }
+}


### PR DESCRIPTION
Previously, the system id was postfixed to the vehicle id for the cache key, in order to provide efficient lookup during expiry event cleanup. However, this prevents simple lookup by id in the cache (as in #167) if you don't know which system the vehicle belongs to. This PR moves the burden to the expiry event handler to loop through all entries in the spatial index to find the right entry to expire. This needs to be properly tested.