### PR TITLE
let CI publish Docker image, tweak Dockerfile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,10 +27,6 @@ aliases:
       echo 'export CIRCLE_SHA1="$CIRCLE_SHA1"' >> $BASH_ENV
       echo 'export CIRCLE_PROJECT_REPONAME="$CIRCLE_PROJECT_REPONAME"' >> $BASH_ENV
        .circleci/trigger_build_v2.sh "entur/lamassu-deployment-config.git" "master" "$(git log -1 --pretty=%B)"
-  - &docker-build
-    name: Docker build
-    command: |
-      DOCKER_BUILDKIT=1 docker build .
 
 jobs:
   test:
@@ -108,18 +104,6 @@ jobs:
       # Cannot use -o because of snapshot dependencies.
       - run: mvn deploy -s .circleci/settings.xml -P prettierSkip -DskipTests
       - run: *post_build
-  docker-build:
-    docker:
-      - image: cimg/openjdk:17.0.8
-        auth:
-          username: $DOCKERHUB_LOGIN
-          password: $DOCKERHUB_PASSWORD
-    steps:
-      - setup_remote_docker:
-          version: 20.10.24
-      - checkout
-      - run: *docker-build
-
 workflows:
   version: 2.1
   release:
@@ -136,6 +120,3 @@ workflows:
                 - master
           requires:
             - test-release
-      - docker-build:
-            name: docker-build
-            context: global

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,13 @@
 /.git
 
+/Dockerfile
+
 /target
 # !**/src/main/**/target/
 # !**/src/test/**/target/
+
+/.circleci
+/.github
 
 ### STS ###
 .apt_generated

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -31,10 +31,10 @@ jobs:
     - name: build and push Docker image
       uses: docker/build-push-action@v4
       with:
-        push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        push: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'ci-docker-push') }}
         tags: |
           entur/lamassu:latest
-        platforms: linux/amd64
+        platforms: linux/amd64,linux/arm64
         # https://docs.docker.com/build/ci/github-actions/cache/#cache-backend-api
         cache-from: type=gha
         cache-to: type=gha,mode=max

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,0 +1,40 @@
+name: build Docker image, optionally publish it
+
+on:
+  push:
+    branches:
+      - '*'
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  test:
+    name: test
+    uses: './.github/workflows/test.yml'
+
+  build-publish:
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4
+
+    - name: set up Docker buildx
+      uses: docker/setup-buildx-action@v2
+    - name: log into the Docker Hub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - name: build and push Docker image
+      uses: docker/build-push-action@v4
+      with:
+        push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        tags: |
+          entur/lamassu:latest
+        platforms: linux/amd64
+        # https://docs.docker.com/build/ci/github-actions/cache/#cache-backend-api
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,16 +25,16 @@ jobs:
 
     - name: refresh Maven cache
       run: |
-        mvn org.apache.maven.plugins:maven-dependency-plugin:3.1.0:go-offline -s settings.xml
+        mvn org.apache.maven.plugins:maven-dependency-plugin:3.1.0:go-offline -s mvn-settings.xml
 
     # Cannot use -o because of snapshot dependencies.
     - name: run Maven verify
       run: |
-        mvn verify -s settings.xml
+        mvn verify -s mvn-settings.xml
 
     - name: Sonar scan
       run: |
-        mvn -s settings.xml \
+        mvn -s mvn-settings.xml \
           org.jacoco:jacoco-maven-plugin:prepare-agent verify \
           org.jacoco:jacoco-maven-plugin:report sonar:sonar \
           -Dmaven.main.skip \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
       - '*'
+  # make workflow "callable" by others
+  workflow_call:
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,44 @@
+name: test
+
+on:
+  push:
+    branches:
+      - '*'
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      JFROG_USER: ${{ secrets.ARTIFACTORY_USER }}
+      JFROG_PASS: ${{ secrets.ARTIFACTORY_PASSWORD }}
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4
+    - name: download Maven settings
+      run: |
+        wget https://raw.githubusercontent.com/entur/circleci-toolbox-image-java11/master/tools/m2/settings.xml -O mvn-settings.xml
+
+    - name: refresh Maven cache
+      run: |
+        mvn org.apache.maven.plugins:maven-dependency-plugin:3.1.0:go-offline -s settings.xml
+
+    # Cannot use -o because of snapshot dependencies.
+    - name: run Maven verify
+      run: |
+        mvn verify -s settings.xml
+
+    - name: Sonar scan
+      run: |
+        mvn -s settings.xml \
+          org.jacoco:jacoco-maven-plugin:prepare-agent verify \
+          org.jacoco:jacoco-maven-plugin:report sonar:sonar \
+          -Dmaven.main.skip \
+          -DskipTests \
+          -Dsonar.projectKey=entur_${{ github.event.repository.name }} \
+          -Dsonar.organization=${{ secrets.SONAR_ORG }} \
+          -Dsonar.projectName=${{ github.event.repository.name }} \
+          -Dsonar.host.url=https://sonarcloud.io \
+          -Dsonar.login=${{ secrets.SONAR_PASSWORD }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN --mount=type=bind,source=pom.xml,target=pom.xml \
     env CI=true \
     ./mvnw install -DskipTests -P prettierSkip
 
-FROM eclipse-temurin:17.0.8_7-jdk-alpine
+FROM eclipse-temurin:17.0.8_7-jre-alpine
 
 RUN apk update && apk upgrade && apk add --no-cache \
     tini

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,9 @@ WORKDIR /home/appuser
 RUN chown -R appuser:appuser /home/appuser
 USER appuser
 
+EXPOSE 8080
+EXPOSE 9001
+
 # todo: don't hard-code lamassu's version here
 COPY --from=builder target/lamassu-0.0.1-SNAPSHOT.jar lamassu.jar
 

--- a/pom.xml
+++ b/pom.xml
@@ -284,4 +284,12 @@
             </build>
         </profile>
     </profiles>
+    <repositories>
+        <repository>
+            <id>central</id>
+            <name>Maven Repository Switchboard</name>
+            <layout>default</layout>
+            <url>https://repo1.maven.org/maven2</url>
+        </repository>
+    </repositories>
 </project>


### PR DESCRIPTION
This PR changes the CI config, on `master`, to build a Docker image and publish it as `entur/lamassu` to the Docker Hub.

---

*Note:* I cannot view the CI run's output without logging in, so you'll have to tell me if something is broken.
*Note:* You can [push into this PR's branch directly](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/committing-changes-to-a-pull-request-branch-created-from-a-fork), you don't need to create a separate PR.