### PR TITLE
Add formFactor filter for operators graphql query

### DIFF
--- a/src/main/java/org/entur/lamassu/controller/GraphQLQueryController.java
+++ b/src/main/java/org/entur/lamassu/controller/GraphQLQueryController.java
@@ -23,6 +23,7 @@ import org.entur.lamassu.service.GeoSearchService;
 import org.entur.lamassu.service.RangeQueryParameters;
 import org.entur.lamassu.service.StationFilterParameters;
 import org.entur.lamassu.service.VehicleFilterParameters;
+import org.entur.lamassu.util.OperatorFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -62,8 +63,8 @@ public class GraphQLQueryController implements GraphQLQueryResolver {
       .collect(Collectors.toSet());
   }
 
-  public Collection<Operator> getOperators() {
-    return feedProviderService.getOperators();
+  public Collection<Operator> getOperators(List<FormFactor> formFactors) {
+    return feedProviderService.getOperators(new OperatorFilter(formFactors));
   }
 
   public Collection<Vehicle> getVehicles(

--- a/src/main/java/org/entur/lamassu/service/FeedProviderService.java
+++ b/src/main/java/org/entur/lamassu/service/FeedProviderService.java
@@ -19,11 +19,13 @@
 package org.entur.lamassu.service;
 
 import java.util.List;
+import org.entur.lamassu.model.entities.FormFactor;
 import org.entur.lamassu.model.entities.Operator;
 import org.entur.lamassu.model.provider.FeedProvider;
+import org.entur.lamassu.util.OperatorFilter;
 
 public interface FeedProviderService {
   List<FeedProvider> getFeedProviders();
-  List<Operator> getOperators();
+  List<Operator> getOperators(OperatorFilter operatorFilter);
   FeedProvider getFeedProviderBySystemId(String systemId);
 }

--- a/src/main/java/org/entur/lamassu/service/impl/FeedProviderServiceImpl.java
+++ b/src/main/java/org/entur/lamassu/service/impl/FeedProviderServiceImpl.java
@@ -23,9 +23,11 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import org.entur.lamassu.config.feedprovider.FeedProviderConfig;
 import org.entur.lamassu.mapper.entitymapper.TranslationMapper;
+import org.entur.lamassu.model.entities.FormFactor;
 import org.entur.lamassu.model.entities.Operator;
 import org.entur.lamassu.model.provider.FeedProvider;
 import org.entur.lamassu.service.FeedProviderService;
+import org.entur.lamassu.util.OperatorFilter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -55,9 +57,10 @@ public class FeedProviderServiceImpl implements FeedProviderService {
   }
 
   @Override
-  public List<Operator> getOperators() {
+  public List<Operator> getOperators(OperatorFilter operatorFilter) {
     return getFeedProviders()
       .stream()
+      .filter(feedProvider -> operatorFilter.matches(feedProvider))
       .map(this::mapOperator)
       .distinct()
       .collect(Collectors.toList());

--- a/src/main/java/org/entur/lamassu/util/OperatorFilter.java
+++ b/src/main/java/org/entur/lamassu/util/OperatorFilter.java
@@ -1,0 +1,35 @@
+package org.entur.lamassu.util;
+
+import java.util.List;
+import java.util.Locale;
+import org.entur.lamassu.model.entities.FormFactor;
+import org.entur.lamassu.model.provider.FeedProvider;
+
+public class OperatorFilter {
+
+  private final List<FormFactor> formFactors;
+
+  public OperatorFilter(List<FormFactor> formFactors) {
+    this.formFactors = formFactors;
+  }
+
+  public boolean matches(FeedProvider feedProvider) {
+    return this.hasFormFactor(feedProvider);
+  }
+
+  public boolean hasFormFactor(FeedProvider feedProvider) {
+    if (
+      this.formFactors != null &&
+      !this.formFactors.isEmpty() &&
+      feedProvider
+        .getVehicleTypes()
+        .stream()
+        .noneMatch(vt ->
+          this.formFactors.contains(FormFactor.valueOf(vt.getFormFactor().name()))
+        )
+    ) {
+      return false;
+    }
+    return true;
+  }
+}

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -1,7 +1,10 @@
 type Query {
     codespaces: [String]
 
-    operators: [Operator]
+    operators(
+        "Filter by form factors"
+        formFactors: [FormFactor]
+    ):[Operator]
 
     vehicle(id: String!): Vehicle
 

--- a/src/test/java/org/entur/lamassu/util/OperatorFilterTest.java
+++ b/src/test/java/org/entur/lamassu/util/OperatorFilterTest.java
@@ -1,0 +1,49 @@
+package org.entur.lamassu.util;
+
+import java.util.List;
+import org.entur.gbfs.v2_3.vehicle_types.GBFSVehicleType;
+import org.entur.lamassu.model.entities.FormFactor;
+import org.entur.lamassu.model.provider.FeedProvider;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class OperatorFilterTest {
+
+  @Test
+  public void testFilterNoFormFactorGiven() {
+    OperatorFilter filter = new OperatorFilter(null);
+    Assert.assertTrue(filter.matches(carRentingMockProvider()));
+  }
+
+  @Test
+  public void testFilterMatchingFormFactorGiven() {
+    OperatorFilter filter = new OperatorFilter(List.of(FormFactor.CAR));
+    Assert.assertTrue(filter.matches(carRentingMockProvider()));
+  }
+
+  @Test
+  public void testFilterNotMatchingFormFactorGiven() {
+    OperatorFilter filter = new OperatorFilter(List.of(FormFactor.BICYCLE));
+    Assert.assertFalse(filter.matches(carRentingMockProvider()));
+  }
+
+  @Test
+  public void testFilterMatchingOneOfMultipleFormFactorsGiven() {
+    OperatorFilter filter = new OperatorFilter(
+      List.of(FormFactor.BICYCLE, FormFactor.CAR)
+    );
+    Assert.assertTrue(filter.matches(carRentingMockProvider()));
+  }
+
+  private FeedProvider carRentingMockProvider() {
+    var feedProvider = new FeedProvider();
+    feedProvider.setSystemId("testsystem");
+    feedProvider.setCodespace("TST");
+    feedProvider.setLanguage("en");
+
+    GBFSVehicleType carVehicleType = new GBFSVehicleType();
+    carVehicleType.setFormFactor(GBFSVehicleType.FormFactor.CAR);
+    feedProvider.setVehicleTypes(List.of(carVehicleType));
+    return feedProvider;
+  }
+}


### PR DESCRIPTION
This PR adds `formFactor` as optional filter to the graphql `operators` query.

An operator matches a given `formFactor`, if any `vehicle_type` it rents has of the requested `formFactor`s.

Note: this filter evaluates `vehicle_types`, not currently available vehicle_types.  