### PR TITLE
CI: build & publish linux/arm64 images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,4 +59,8 @@ jobs:
       - name: Build container image with Jib, push to container repo
         run: |
           image_date=`date +%Y-%m-%dT%H-%M`
-          mvn --batch-mode compile com.google.cloud.tools:jib-maven-plugin:build -Djib.to.tags=latest,$image_date -Dmaven.test.skip -P prettierSkip
+          mvn --batch-mode compile \
+            com.google.cloud.tools:jib-maven-plugin:build \
+            -Djib.to.tags=latest,"$image_date" \
+            -Dmaven.test.skip \
+            -P prettierSkip

--- a/pom.xml
+++ b/pom.xml
@@ -299,7 +299,17 @@
                 </dependencies>
                 <configuration>
                     <from>
-                        <image>eclipse-temurin:21.0.1_12-jdk-alpine</image>
+                        <image>eclipse-temurin:21.0.1_12-jre</image>
+                        <platforms>
+                            <platform>
+                                <architecture>amd64</architecture>
+                                <os>linux</os>
+                            </platform>
+                            <platform>
+                                <architecture>arm64</architecture>
+                                <os>linux</os>
+                            </platform>
+                        </platforms>
                     </from>
                     <to>
                         <image>${env.CONTAINER_REPO}</image>


### PR DESCRIPTION
remotely related: #249

This PR configures Jib to build `linux/arm64` images, so one can run them natively on ARM machines, as documented [here](https://github.com/GoogleContainerTools/jib/tree/bb36a18a94fb0b7beb9203cf359bc88a95e038da/jib-maven-plugin#from-object).