### PR TITLE
Handle missing vehicle_types_available gracefully

### DIFF
--- a/src/main/java/org/entur/lamassu/util/SpatialIndexIdUtil.java
+++ b/src/main/java/org/entur/lamassu/util/SpatialIndexIdUtil.java
@@ -1,5 +1,6 @@
 package org.entur.lamassu.util;
 
+import java.util.Collections;
 import java.util.stream.Collectors;
 import org.entur.lamassu.cache.StationSpatialIndexId;
 import org.entur.lamassu.cache.VehicleSpatialIndexId;
@@ -37,20 +38,29 @@ public class SpatialIndexIdUtil {
     id.setCodespace(feedProvider.getCodespace());
     id.setSystemId(feedProvider.getSystemId());
     id.setOperatorId(feedProvider.getOperatorId());
-    id.setAvailableFormFactors(
-      station
-        .getVehicleTypesAvailable()
-        .stream()
-        .map(vta -> vta.getVehicleType().getFormFactor())
-        .collect(Collectors.toList())
-    );
-    id.setAvailablePropulsionTypes(
-      station
-        .getVehicleTypesAvailable()
-        .stream()
-        .map(vta -> vta.getVehicleType().getPropulsionType())
-        .collect(Collectors.toList())
-    );
+    if (station.getVehicleTypesAvailable() != null) {
+      id.setAvailableFormFactors(
+        station
+          .getVehicleTypesAvailable()
+          .stream()
+          .map(vta -> vta.getVehicleType().getFormFactor())
+          .collect(Collectors.toList())
+      );
+      id.setAvailablePropulsionTypes(
+        station
+          .getVehicleTypesAvailable()
+          .stream()
+          .map(vta -> vta.getVehicleType().getPropulsionType())
+          .collect(Collectors.toList())
+      );
+    } else {
+      // Note: in case no validation is activated, this issue would slip
+      // silently. On the other hand, logging it here for every station would
+      // be overwhelming...
+      id.setAvailableFormFactors(Collections.EMPTY_LIST);
+      id.setAvailablePropulsionTypes(Collections.EMPTY_LIST);
+    }
+
     return id;
   }
 }

--- a/src/test/java/org/entur/lamassu/util/SpatialIndexIdFilterTest.java
+++ b/src/test/java/org/entur/lamassu/util/SpatialIndexIdFilterTest.java
@@ -20,7 +20,7 @@ public class SpatialIndexIdFilterTest {
   @Test
   public void testNoFilter() {
     Assert.assertTrue(
-      SpatialIndexIdFilter.filterVehicle(testVehicleId(), testVehicleFilterParams())
+      SpatialIndexIdFilter.filterVehicle(aVehicleId(), aVehicleFilterParams())
     );
   }
 
@@ -28,18 +28,18 @@ public class SpatialIndexIdFilterTest {
   public void testNoFilterReturnsStationWithoutVehicleTypesAvailable() {
     StationSpatialIndexId stationSpatialIndexId =
       SpatialIndexIdUtil.createStationSpatialIndexId(
-        testStationWithoutVehicleTypeAvailability(),
-        testProvider()
+        aStationWithoutVehicleTypeAvailability(),
+        aProvider()
       );
     Assert.assertTrue(
-      SpatialIndexIdFilter.filterStation(stationSpatialIndexId, testStationFilterParams())
+      SpatialIndexIdFilter.filterStation(stationSpatialIndexId, aStationFilterParams())
     );
   }
 
   @Test
   public void testCodespaceFilter() {
-    var testId = testVehicleId();
-    var params = testVehicleFilterParams();
+    var testId = aVehicleId();
+    var params = aVehicleFilterParams();
 
     params.setCodespaces(List.of("TST"));
     Assert.assertTrue(SpatialIndexIdFilter.filterVehicle(testId, params));
@@ -50,8 +50,8 @@ public class SpatialIndexIdFilterTest {
 
   @Test
   public void testSystemFilter() {
-    var testId = testVehicleId();
-    var params = testVehicleFilterParams();
+    var testId = aVehicleId();
+    var params = aVehicleFilterParams();
 
     params.setSystems(List.of("TST:System:testprovider"));
     Assert.assertTrue(SpatialIndexIdFilter.filterVehicle(testId, params));
@@ -62,8 +62,8 @@ public class SpatialIndexIdFilterTest {
 
   @Test
   public void testOperatorFilter() {
-    var testId = testVehicleId();
-    var params = testVehicleFilterParams();
+    var testId = aVehicleId();
+    var params = aVehicleFilterParams();
 
     params.setOperators(List.of("TST:Operator:test"));
     Assert.assertTrue(SpatialIndexIdFilter.filterVehicle(testId, params));
@@ -74,8 +74,8 @@ public class SpatialIndexIdFilterTest {
 
   @Test
   public void testFormFactorFilter() {
-    var testId = testVehicleId();
-    var params = testVehicleFilterParams();
+    var testId = aVehicleId();
+    var params = aVehicleFilterParams();
 
     params.setFormFactors(List.of(FormFactor.SCOOTER));
     Assert.assertTrue(SpatialIndexIdFilter.filterVehicle(testId, params));
@@ -86,8 +86,8 @@ public class SpatialIndexIdFilterTest {
 
   @Test
   public void testPropulsionTypeFilter() {
-    var testId = testVehicleId();
-    var params = testVehicleFilterParams();
+    var testId = aVehicleId();
+    var params = aVehicleFilterParams();
 
     params.setPropulsionTypes(List.of(PropulsionType.ELECTRIC));
     Assert.assertTrue(SpatialIndexIdFilter.filterVehicle(testId, params));
@@ -98,8 +98,8 @@ public class SpatialIndexIdFilterTest {
 
   @Test
   public void testIncludeReservedFilter() {
-    var testId = testReservedId();
-    var params = testVehicleFilterParams();
+    var testId = aReservedId();
+    var params = aVehicleFilterParams();
 
     params.setIncludeReserved(true);
     Assert.assertTrue(SpatialIndexIdFilter.filterVehicle(testId, params));
@@ -110,8 +110,8 @@ public class SpatialIndexIdFilterTest {
 
   @Test
   public void testIncludeDisabledFilter() {
-    var testId = testDisabledId();
-    var params = testVehicleFilterParams();
+    var testId = aDisabledId();
+    var params = aVehicleFilterParams();
 
     params.setIncludeDisabled(true);
     Assert.assertTrue(SpatialIndexIdFilter.filterVehicle(testId, params));
@@ -122,7 +122,7 @@ public class SpatialIndexIdFilterTest {
 
   @Test
   public void testVehicleTypesAvailableFilter() {
-    var testId = testStationId();
+    var testId = aStationId();
     var params = new StationFilterParameters();
 
     params.setAvailableFormFactors(List.of(FormFactor.SCOOTER));
@@ -141,52 +141,52 @@ public class SpatialIndexIdFilterTest {
     Assert.assertFalse(SpatialIndexIdFilter.filterStation(testId, params));
   }
 
-  private VehicleSpatialIndexId testVehicleId() {
-    return SpatialIndexIdUtil.createVehicleSpatialIndexId(testVehicle(), testProvider());
+  private VehicleSpatialIndexId aVehicleId() {
+    return SpatialIndexIdUtil.createVehicleSpatialIndexId(aVehicle(), aProvider());
   }
 
-  private StationSpatialIndexId testStationId() {
-    return SpatialIndexIdUtil.createStationSpatialIndexId(testStation(), testProvider());
+  private StationSpatialIndexId aStationId() {
+    return SpatialIndexIdUtil.createStationSpatialIndexId(aStation(), aProvider());
   }
 
-  private VehicleSpatialIndexId testReservedId() {
-    var vehicle = testVehicle();
+  private VehicleSpatialIndexId aReservedId() {
+    var vehicle = aVehicle();
     vehicle.setReserved(true);
-    return SpatialIndexIdUtil.createVehicleSpatialIndexId(vehicle, testProvider());
+    return SpatialIndexIdUtil.createVehicleSpatialIndexId(vehicle, aProvider());
   }
 
-  private VehicleSpatialIndexId testDisabledId() {
-    var vehicle = testVehicle();
+  private VehicleSpatialIndexId aDisabledId() {
+    var vehicle = aVehicle();
     vehicle.setDisabled(true);
-    return SpatialIndexIdUtil.createVehicleSpatialIndexId(vehicle, testProvider());
+    return SpatialIndexIdUtil.createVehicleSpatialIndexId(vehicle, aProvider());
   }
 
-  private Vehicle testVehicle() {
+  private Vehicle aVehicle() {
     var vehicle = new Vehicle();
     vehicle.setId("TST:Vehicle:abc123");
     vehicle.setReserved(false);
     vehicle.setDisabled(false);
-    vehicle.setVehicleType(scooterVehicle());
+    vehicle.setVehicleType(aScooterVehicle());
     return vehicle;
   }
 
-  private Station testStation() {
+  private Station aStation() {
     var station = new Station();
     station.setId("TST:Station:foobar");
     var vehicleTypeAvailability = new VehicleTypeAvailability();
-    vehicleTypeAvailability.setVehicleType(scooterVehicle());
+    vehicleTypeAvailability.setVehicleType(aScooterVehicle());
     vehicleTypeAvailability.setCount(1);
     station.setVehicleTypesAvailable(List.of(vehicleTypeAvailability));
     return station;
   }
 
-  private Station testStationWithoutVehicleTypeAvailability() {
+  private Station aStationWithoutVehicleTypeAvailability() {
     var station = new Station();
     station.setId("TST:Station:no_vta");
     return station;
   }
 
-  private VehicleType scooterVehicle() {
+  private VehicleType aScooterVehicle() {
     var type = new VehicleType();
     type.setId("TST:VehicleType:Scooter");
     type.setFormFactor(FormFactor.SCOOTER);
@@ -194,7 +194,7 @@ public class SpatialIndexIdFilterTest {
     return type;
   }
 
-  private FeedProvider testProvider() {
+  private FeedProvider aProvider() {
     var provider = new FeedProvider();
     provider.setCodespace("TST");
     provider.setSystemId("TST:System:testprovider");
@@ -203,14 +203,14 @@ public class SpatialIndexIdFilterTest {
     return provider;
   }
 
-  private VehicleFilterParameters testVehicleFilterParams() {
+  private VehicleFilterParameters aVehicleFilterParams() {
     var params = new VehicleFilterParameters();
     params.setIncludeReserved(false);
     params.setIncludeDisabled(false);
     return params;
   }
 
-  private StationFilterParameters testStationFilterParams() {
+  private StationFilterParameters aStationFilterParams() {
     var params = new StationFilterParameters();
     return params;
   }

--- a/src/test/java/org/entur/lamassu/util/SpatialIndexIdFilterTest.java
+++ b/src/test/java/org/entur/lamassu/util/SpatialIndexIdFilterTest.java
@@ -26,9 +26,13 @@ public class SpatialIndexIdFilterTest {
 
   @Test
   public void testNoFilterReturnsStationWithoutVehicleTypesAvailable() {
-    StationSpatialIndexId stationSpatialIndexId = SpatialIndexIdUtil.createStationSpatialIndexId(testStationWithoutVehicleTypeAvailability(), testProvider());
+    StationSpatialIndexId stationSpatialIndexId =
+      SpatialIndexIdUtil.createStationSpatialIndexId(
+        testStationWithoutVehicleTypeAvailability(),
+        testProvider()
+      );
     Assert.assertTrue(
-            SpatialIndexIdFilter.filterStation(stationSpatialIndexId, testStationFilterParams())
+      SpatialIndexIdFilter.filterStation(stationSpatialIndexId, testStationFilterParams())
     );
   }
 

--- a/src/test/java/org/entur/lamassu/util/SpatialIndexIdFilterTest.java
+++ b/src/test/java/org/entur/lamassu/util/SpatialIndexIdFilterTest.java
@@ -25,6 +25,14 @@ public class SpatialIndexIdFilterTest {
   }
 
   @Test
+  public void testNoFilterReturnsStationWithoutVehicleTypesAvailable() {
+    StationSpatialIndexId stationSpatialIndexId = SpatialIndexIdUtil.createStationSpatialIndexId(testStationWithoutVehicleTypeAvailability(), testProvider());
+    Assert.assertTrue(
+            SpatialIndexIdFilter.filterStation(stationSpatialIndexId, testStationFilterParams())
+    );
+  }
+
+  @Test
   public void testCodespaceFilter() {
     var testId = testVehicleId();
     var params = testVehicleFilterParams();
@@ -168,6 +176,12 @@ public class SpatialIndexIdFilterTest {
     return station;
   }
 
+  private Station testStationWithoutVehicleTypeAvailability() {
+    var station = new Station();
+    station.setId("TST:Station:no_vta");
+    return station;
+  }
+
   private VehicleType scooterVehicle() {
     var type = new VehicleType();
     type.setId("TST:VehicleType:Scooter");
@@ -189,6 +203,11 @@ public class SpatialIndexIdFilterTest {
     var params = new VehicleFilterParameters();
     params.setIncludeReserved(false);
     params.setIncludeDisabled(false);
+    return params;
+  }
+
+  private StationFilterParameters testStationFilterParams() {
+    var params = new StationFilterParameters();
     return params;
   }
 }


### PR DESCRIPTION
This PR partly addresses #250 (partly) by treating missing `station.vehicle_types_available` as empty arrays.
Note: it does not provide better loggging, but only fixes an ingestion exception with missing `vehicle_types_available`.

In consequence, no exceptions are logged for e.g. this feed configuration:

```yaml
lamassu:
  providers:
    - systemId: lime_zu
      operatorId: LME:Operator:lime
      operatorName: Lime
      codespace: DKY
      url: "https://data.lime.bike/api/partners/v2/gbfs/zug/gbfs.json"
      language: en
```

and the following queries returned expected results:

## GBFS queries tested
http://localhost:8080/gbfs/lime_zu/gbfs
http://localhost:8080/gbfs/lime_zu/station_status
http://localhost:8080/gbfs/lime_zu/station_information

Before: Whitelabel Error page
After: gfbs/station_status/station_information is shown

http://localhost:8080/validation/systems/lime_zu
Before: []
After: Validation reporting `#/data/stations/0: required key [vehicle_types_available] not found`


## GrapqhiQL Queries tested

```graphiql
{operators {
  id
}}
```

returned operator

{stations(range: 10000000, lon: 8.516, lat: 47.1528) {
  id
}}

Did not returns any station though, as pricing_plans are provided by this feed. 

@testower is there a way to configure pricing_plans in lamassu, so the stations can be cached anyway? I tested without success:

```yaml
lamassu:
  providers:
    - systemId: lime_zu
      operatorId: LME:Operator:lime
      operatorName: Lime
      codespace: DKY
      url: "https://data.lime.bike/api/partners/v2/gbfs/zug/gbfs.json"
      language: en
      pricing_plans:
        planId: TestPlan
        name: TestPlan
        price: 0.0
        isTaxable: False
        currency: EUR
```


