### PR TITLE
Add optional scope to outh2 configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Some providers may require authentication, e.g. via bearer token, OAuth2 or cust
                     tokenUrl: "https://mytokenurl.example/"
                     clientId: my-client-id
                     clientPassword: my-client-password
+                    scope: optional-scope
             ...
           - systemId: my_bearer_secured_system
             authentication:

--- a/src/main/java/org/entur/lamassu/model/provider/Authentication.java
+++ b/src/main/java/org/entur/lamassu/model/provider/Authentication.java
@@ -35,7 +35,8 @@ public class Authentication {
       return new Oauth2ClientCredentialsGrantRequestAuthenticator(
         URI.create(properties.get("tokenUrl")),
         properties.get("clientId"),
-        properties.get("clientPassword")
+        properties.get("clientPassword"),
+        properties.get("scope")
       );
     } else if (scheme == AuthenticationScheme.BEARER_TOKEN) {
       return new BearerTokenRequestAuthenticator(properties.get("accessToken"));


### PR DESCRIPTION
This PR adds the possibility to add a scope to the OAuth2 configuration.

This addition has been tested successfully with a feed from provider TIER.

Note: this PR requires the merge of https://github.com/entur/gbfs-loader-java/pull/118 and release of a new `gbfs-loader-java` version and a corresponding upgrade in `pom.xml`.