### PR TITLE
fix: do not skip vehicles without pricing plan id (fixes #396)

### DIFF
--- a/src/main/java/org/entur/lamassu/leader/entityupdater/VehicleFilter.java
+++ b/src/main/java/org/entur/lamassu/leader/entityupdater/VehicleFilter.java
@@ -48,7 +48,10 @@ class VehicleFilter implements Predicate<GBFSBike> {
       return false;
     }
 
-    if (!pricingPlans.containsKey(vehicle.getPricingPlanId())) {
+    if (
+      vehicle.getPricingPlanId() != null &&
+      !pricingPlans.containsKey(vehicle.getPricingPlanId())
+    ) {
       logger.info("Skipping vehicle with unknown pricing plan id {}", vehicle);
       return false;
     }

--- a/src/main/java/org/entur/lamassu/leader/entityupdater/VehicleFilter.java
+++ b/src/main/java/org/entur/lamassu/leader/entityupdater/VehicleFilter.java
@@ -52,12 +52,32 @@ class VehicleFilter implements Predicate<GBFSBike> {
       vehicle.getPricingPlanId() != null &&
       !pricingPlans.containsKey(vehicle.getPricingPlanId())
     ) {
-      logger.info("Skipping vehicle with unknown pricing plan id {}", vehicle);
+      logger.info(
+        "Skipping vehicle with unknown pricing plan id {} (vehicle {})",
+        vehicle.getPricingPlanId(),
+        vehicle.getBikeId()
+      );
       return false;
     }
 
     if (!vehicleTypes.containsKey(vehicle.getVehicleTypeId())) {
-      logger.info("Skipping vehicle with unknown vehicle type id {}", vehicle);
+      logger.info(
+        "Skipping vehicle with unknown vehicle type id {} (vehicle {})",
+        vehicle.getVehicleTypeId(),
+        vehicle.getBikeId()
+      );
+      return false;
+    }
+
+    if (
+      vehicle.getPricingPlanId() == null &&
+      vehicleTypes.get(vehicle.getVehicleTypeId()).getDefaultPricingPlan() == null
+    ) {
+      logger.info(
+        "Skipping vehicle without pricing plan id and vehicle type {} without default pricing plan (vehicle {})",
+        vehicle.getVehicleTypeId(),
+        vehicle.getBikeId()
+      );
       return false;
     }
 

--- a/src/main/java/org/entur/lamassu/leader/entityupdater/VehiclesUpdater.java
+++ b/src/main/java/org/entur/lamassu/leader/entityupdater/VehiclesUpdater.java
@@ -156,7 +156,10 @@ public class VehiclesUpdater {
         vehicleMapper.mapVehicle(
           vehicle,
           vehicleTypes.get(vehicle.getVehicleTypeId()),
-          pricingPlans.get(vehicle.getPricingPlanId()),
+          // pricingPlanId is optional for vehicles and defaults to it's vehicleType's default pricing plan
+          vehicle.getPricingPlanId() != null
+            ? pricingPlans.get(vehicle.getPricingPlanId())
+            : vehicleTypes.get(vehicle.getVehicleTypeId()).getDefaultPricingPlan(),
           system
         )
       )

--- a/src/test/java/org/entur/lamassu/leader/entityupdater/VehicleFilterTest.java
+++ b/src/test/java/org/entur/lamassu/leader/entityupdater/VehicleFilterTest.java
@@ -1,0 +1,26 @@
+package org.entur.lamassu.leader.entityupdater;
+
+import java.util.HashMap;
+import org.entur.gbfs.v2_3.free_bike_status.GBFSBike;
+import org.entur.gbfs.v2_3.vehicle_types.GBFSVehicleType;
+import org.entur.gbfs.v2_3.vehicle_types.GBFSVehicleTypes;
+import org.junit.Test;
+
+public class VehicleFilterTest {
+
+  @Test
+  public void testVehicleWithoutPricingPlanIsntSkipped() {
+    GBFSVehicleType vehicleType = new GBFSVehicleType();
+    vehicleType.setVehicleTypeId("vehicleTypeId");
+    HashMap vehicleTypes = new HashMap<String, GBFSVehicleTypes>();
+    vehicleTypes.put(vehicleType.getVehicleTypeId(), vehicleType);
+
+    VehicleFilter filter = new VehicleFilter(new HashMap<>(), vehicleTypes);
+
+    GBFSBike vehicle = new GBFSBike();
+    vehicle.setBikeId("VehicleWithoutPricingPlan");
+    vehicle.setVehicleTypeId("vehicleTypeId");
+
+    assert filter.test(vehicle) == true;
+  }
+}

--- a/src/test/java/org/entur/lamassu/leader/entityupdater/VehicleFilterTest.java
+++ b/src/test/java/org/entur/lamassu/leader/entityupdater/VehicleFilterTest.java
@@ -2,25 +2,50 @@ package org.entur.lamassu.leader.entityupdater;
 
 import java.util.HashMap;
 import org.entur.gbfs.v2_3.free_bike_status.GBFSBike;
-import org.entur.gbfs.v2_3.vehicle_types.GBFSVehicleType;
-import org.entur.gbfs.v2_3.vehicle_types.GBFSVehicleTypes;
+import org.entur.lamassu.model.entities.PricingPlan;
+import org.entur.lamassu.model.entities.VehicleType;
 import org.junit.Test;
 
 public class VehicleFilterTest {
 
-  @Test
-  public void testVehicleWithoutPricingPlanIsntSkipped() {
-    GBFSVehicleType vehicleType = new GBFSVehicleType();
-    vehicleType.setVehicleTypeId("vehicleTypeId");
-    HashMap vehicleTypes = new HashMap<String, GBFSVehicleTypes>();
-    vehicleTypes.put(vehicleType.getVehicleTypeId(), vehicleType);
+  private static String VEHICLE_TYPE_ID = "vehicleTypeId";
 
-    VehicleFilter filter = new VehicleFilter(new HashMap<>(), vehicleTypes);
+  private HashMap<String, VehicleType> vehicleTypesWithPricingPlan(
+    PricingPlan optionalPricingPlan
+  ) {
+    VehicleType vehicleType = new VehicleType();
+    vehicleType.setDefaultPricingPlan(optionalPricingPlan);
+    HashMap<String, VehicleType> vehicleTypes = new HashMap<>();
+    vehicleTypes.put(VEHICLE_TYPE_ID, vehicleType);
+
+    return vehicleTypes;
+  }
+
+  @Test
+  public void testVehicleWithoutPricingPlanButDefaultPricingPlanIsntSkipped() {
+    VehicleFilter filter = new VehicleFilter(
+      new HashMap<>(),
+      vehicleTypesWithPricingPlan(new PricingPlan())
+    );
 
     GBFSBike vehicle = new GBFSBike();
     vehicle.setBikeId("VehicleWithoutPricingPlan");
     vehicle.setVehicleTypeId("vehicleTypeId");
 
     assert filter.test(vehicle) == true;
+  }
+
+  @Test
+  public void testVehicleWithoutPricingPlanAndWithoutDefaultPricingPlanIsSkipped() {
+    VehicleFilter filter = new VehicleFilter(
+      new HashMap<>(),
+      vehicleTypesWithPricingPlan(null)
+    );
+
+    GBFSBike vehicle = new GBFSBike();
+    vehicle.setBikeId("VehicleWithoutPricingPlan");
+    vehicle.setVehicleTypeId("vehicleTypeId");
+
+    assert filter.test(vehicle) == false;
   }
 }


### PR DESCRIPTION
### Summary

This PR changes VehicleFilter to not skip vehicles with their pricing_plan_id not set

### Issue
Closes #396

### Unit tests
A unit test to demonstrate this issue was added.

### Bumping the serialization version id
n.a.