### PR TITLE
Respond with status code 502 if configured feed not yet available

### DIFF
--- a/src/main/java/org/entur/lamassu/controller/GBFSInternalV2FeedController.java
+++ b/src/main/java/org/entur/lamassu/controller/GBFSInternalV2FeedController.java
@@ -127,12 +127,6 @@ public class GBFSInternalV2FeedController {
     } catch (IllegalArgumentException e) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST);
     } catch (NoSuchElementException e) {
-      // if system_id is well known and feed is a required one, it should exist and
-      // is not available due to upstream issues.
-      // In this case, we should respond with 5xx and not 4xx
-      if (feedProviderService.getFeedProviderBySystemId(systemId) != null) {
-        throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE);
-      }
       throw new ResponseStatusException(HttpStatus.NOT_FOUND);
     }
   }
@@ -205,8 +199,38 @@ public class GBFSInternalV2FeedController {
     var data = feedCache.find(feedName, feedProvider);
 
     if (data == null) {
+      throwsIfFeedCouldOrShouldExist(feedName, feedProvider);
       throw new NoSuchElementException();
     }
     return data;
+  }
+
+  /*
+      Throws an UpstreamFeedNotYetAvailableException, if either the discoveryFile (gbf file) is not yet cached,
+      the requested feed is published in the discovery file, or the discovery file is malformed.
+     */
+  protected void throwsIfFeedCouldOrShouldExist(
+    GBFSFeedName feedName,
+    FeedProvider feedProvider
+  ) {
+    try {
+      GBFS discoveryFile = (GBFS) feedCache.find(GBFSFeedName.GBFS, feedProvider);
+      if (
+        discoveryFile == null ||
+        ((GBFS) discoveryFile).getFeedsData()
+          .values()
+          .stream()
+          .map(GBFSFeeds::getFeeds)
+          .flatMap(list -> list.stream())
+          .map(GBFSFeed::getName)
+          .anyMatch(name -> name.equals(feedName))
+      ) {
+        throw new UpstreamFeedNotYetAvailableException();
+      }
+    } catch (NullPointerException e) {
+      // in case the gbfs is malformed, e.g. no languages are defined, or no feeds,
+      // this is an upstream error and the requested feed might exist
+      throw new UpstreamFeedNotYetAvailableException();
+    }
   }
 }

--- a/src/main/java/org/entur/lamassu/controller/GBFSInternalV2FeedController.java
+++ b/src/main/java/org/entur/lamassu/controller/GBFSInternalV2FeedController.java
@@ -127,6 +127,12 @@ public class GBFSInternalV2FeedController {
     } catch (IllegalArgumentException e) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST);
     } catch (NoSuchElementException e) {
+      // if system_id is well known and feed is a required one, it should exist and
+      // is not available due to upstream issues.
+      // In this case, we should respond with 5xx and not 4xx
+      if (feedProviderService.getFeedProviderBySystemId(systemId) != null) {
+        throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE);
+      }
       throw new ResponseStatusException(HttpStatus.NOT_FOUND);
     }
   }

--- a/src/main/java/org/entur/lamassu/controller/GBFSV2FeedController.java
+++ b/src/main/java/org/entur/lamassu/controller/GBFSV2FeedController.java
@@ -124,7 +124,7 @@ public class GBFSV2FeedController {
   }
 
   /*
-    Returns true, if either the discoveryFile (gbf file) is not yet cached,
+    Throws an UpstreamFeedNotYetAvailableException, if either the discoveryFile (gbf file) is not yet cached,
     the requested feed is published in the discovery file, or the discovery file is malformed.
    */
   protected void throwsIfFeedCouldOrShouldExist(

--- a/src/main/java/org/entur/lamassu/controller/GBFSV2FeedController.java
+++ b/src/main/java/org/entur/lamassu/controller/GBFSV2FeedController.java
@@ -98,6 +98,12 @@ public class GBFSV2FeedController {
     } catch (IllegalArgumentException e) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST);
     } catch (NoSuchElementException e) {
+      // if system_id is well known and feed is a required one, it should exist and
+      // is not available due to upstream issues.
+      // In this case, we should respond with 5xx and not 4xx
+      if (feedProviderService.getFeedProviderBySystemId(systemId) != null) {
+        throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE);
+      }
       throw new ResponseStatusException(HttpStatus.NOT_FOUND);
     }
   }

--- a/src/main/java/org/entur/lamassu/controller/GBFSV3FeedController.java
+++ b/src/main/java/org/entur/lamassu/controller/GBFSV3FeedController.java
@@ -105,6 +105,12 @@ public class GBFSV3FeedController {
     } catch (IllegalArgumentException e) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST);
     } catch (NoSuchElementException e) {
+      // if system_id is well known and feed is a required one, it should exist and
+      // is not available due to upstream issues.
+      // In this case, we should respond with 5xx and not 4xx
+      if (feedProviderService.getFeedProviderBySystemId(systemId) != null) {
+        throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE);
+      }
       throw new ResponseStatusException(HttpStatus.NOT_FOUND);
     }
   }

--- a/src/main/java/org/entur/lamassu/controller/GBFSV3FeedController.java
+++ b/src/main/java/org/entur/lamassu/controller/GBFSV3FeedController.java
@@ -22,8 +22,10 @@ import java.time.Instant;
 import java.util.NoSuchElementException;
 import java.util.concurrent.TimeUnit;
 import org.entur.gbfs.v3_0.gbfs.GBFSFeed;
+import org.entur.gbfs.v3_0.gbfs.GBFSGbfs;
 import org.entur.gbfs.v3_0.manifest.GBFSManifest;
 import org.entur.lamassu.cache.GBFSV3FeedCache;
+import org.entur.lamassu.model.provider.FeedProvider;
 import org.entur.lamassu.service.FeedProviderService;
 import org.entur.lamassu.service.SystemDiscoveryService;
 import org.entur.lamassu.util.CacheUtil;
@@ -105,12 +107,6 @@ public class GBFSV3FeedController {
     } catch (IllegalArgumentException e) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST);
     } catch (NoSuchElementException e) {
-      // if system_id is well known and feed is a required one, it should exist and
-      // is not available due to upstream issues.
-      // In this case, we should respond with 5xx and not 4xx
-      if (feedProviderService.getFeedProviderBySystemId(systemId) != null) {
-        throw new ResponseStatusException(HttpStatus.BAD_GATEWAY);
-      }
       throw new ResponseStatusException(HttpStatus.NOT_FOUND);
     }
   }
@@ -127,8 +123,40 @@ public class GBFSV3FeedController {
     var data = v3FeedCache.find(feedName, feedProvider);
 
     if (data == null) {
+      throwsIfFeedCouldOrShouldExist(feedName, feedProvider);
       throw new NoSuchElementException();
     }
     return data;
+  }
+
+  /*
+    Throws an UpstreamFeedNotYetAvailableException, if either the discoveryFile (gbf file) is not yet cached,
+    the requested feed is published in the discovery file, or the discovery file is malformed.
+   */
+  protected void throwsIfFeedCouldOrShouldExist(
+    GBFSFeed.Name feedName,
+    FeedProvider feedProvider
+  ) {
+    try {
+      GBFSGbfs discoveryFile = (GBFSGbfs) v3FeedCache.find(
+        GBFSFeed.Name.GBFS,
+        feedProvider
+      );
+      if (
+        discoveryFile == null ||
+        discoveryFile
+          .getData()
+          .getFeeds()
+          .stream()
+          .map(GBFSFeed::getName)
+          .anyMatch(name -> name.equals(feedName))
+      ) {
+        throw new UpstreamFeedNotYetAvailableException();
+      }
+    } catch (NullPointerException e) {
+      // in case the gbfs is malformed, e.g. no languages are defined, or no feeds,
+      // this is an upstream error and the requested feed might exist
+      throw new UpstreamFeedNotYetAvailableException();
+    }
   }
 }

--- a/src/main/java/org/entur/lamassu/controller/GBFSV3FeedController.java
+++ b/src/main/java/org/entur/lamassu/controller/GBFSV3FeedController.java
@@ -109,7 +109,7 @@ public class GBFSV3FeedController {
       // is not available due to upstream issues.
       // In this case, we should respond with 5xx and not 4xx
       if (feedProviderService.getFeedProviderBySystemId(systemId) != null) {
-        throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE);
+        throw new ResponseStatusException(HttpStatus.BAD_GATEWAY);
       }
       throw new ResponseStatusException(HttpStatus.NOT_FOUND);
     }

--- a/src/main/java/org/entur/lamassu/controller/UpstreamFeedNotYetAvailableException.java
+++ b/src/main/java/org/entur/lamassu/controller/UpstreamFeedNotYetAvailableException.java
@@ -21,10 +21,7 @@ package org.entur.lamassu.controller;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
-@ResponseStatus(
-  value = HttpStatus.BAD_GATEWAY,
-  reason = "Feed not (yet) available"
-) //
+@ResponseStatus(value = HttpStatus.BAD_GATEWAY, reason = "Feed not (yet) available")
 public class UpstreamFeedNotYetAvailableException extends RuntimeException {
 
   public UpstreamFeedNotYetAvailableException() {

--- a/src/main/java/org/entur/lamassu/controller/UpstreamFeedNotYetAvailableException.java
+++ b/src/main/java/org/entur/lamassu/controller/UpstreamFeedNotYetAvailableException.java
@@ -1,0 +1,33 @@
+/*
+ *
+ *
+ *  * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ *  * the European Commission - subsequent versions of the EUPL (the "Licence");
+ *  * You may not use this work except in compliance with the Licence.
+ *  * You may obtain a copy of the Licence at:
+ *  *
+ *  *   https://joinup.ec.europa.eu/software/page/eupl
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the Licence is distributed on an "AS IS" basis,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the Licence for the specific language governing permissions and
+ *  * limitations under the Licence.
+ *
+ */
+
+package org.entur.lamassu.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(
+  value = HttpStatus.BAD_GATEWAY,
+  reason = "Feed not (yet) available"
+) //
+public class UpstreamFeedNotYetAvailableException extends RuntimeException {
+
+  public UpstreamFeedNotYetAvailableException() {
+    super();
+  }
+}

--- a/src/test/java/org/entur/lamassu/controller/GBFSV2FeedControllerTest.java
+++ b/src/test/java/org/entur/lamassu/controller/GBFSV2FeedControllerTest.java
@@ -66,8 +66,7 @@ public class GBFSV2FeedControllerTest {
     when(mockedFeedProviderService.getFeedProviderBySystemId(KNOWN_SYSTEM_ID))
       .thenReturn(feedProvider);
 
-    expectedException.expect(ResponseStatusException.class);
-    expectedException.expectMessage("502 BAD_GATEWAY");
+    expectedException.expect(UpstreamFeedNotYetAvailableException.class);
     feedController.getGbfsFeedForProvider(KNOWN_SYSTEM_ID, "gbfs");
   }
 
@@ -98,8 +97,7 @@ public class GBFSV2FeedControllerTest {
     when(mockedFeedCache.find(GBFSFeedName.GBFS, feedProvider)).thenReturn(gbfs);
     when(mockedFeedCache.find(GBFSFeedName.GeofencingZones, feedProvider))
       .thenReturn(null);
-    expectedException.expect(ResponseStatusException.class);
-    expectedException.expectMessage("502 BAD_GATEWAY");
+    expectedException.expect(UpstreamFeedNotYetAvailableException.class);
     feedController.getGbfsFeedForProvider(KNOWN_SYSTEM_ID, "geofencing_zones");
   }
 
@@ -115,8 +113,7 @@ public class GBFSV2FeedControllerTest {
     when(mockedFeedCache.find(GBFSFeedName.GBFS, feedProvider)).thenReturn(gbfs);
     when(mockedFeedCache.find(GBFSFeedName.GeofencingZones, feedProvider))
       .thenReturn(null);
-    expectedException.expect(ResponseStatusException.class);
-    expectedException.expectMessage("502 BAD_GATEWAY");
+    expectedException.expect(UpstreamFeedNotYetAvailableException.class);
     feedController.getGbfsFeedForProvider(KNOWN_SYSTEM_ID, "geofencing_zones");
   }
 

--- a/src/test/java/org/entur/lamassu/controller/GBFSV2FeedControllerTest.java
+++ b/src/test/java/org/entur/lamassu/controller/GBFSV2FeedControllerTest.java
@@ -1,0 +1,132 @@
+package org.entur.lamassu.controller;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import org.entur.gbfs.v2_3.gbfs.GBFS;
+import org.entur.gbfs.v2_3.gbfs.GBFSFeed;
+import org.entur.gbfs.v2_3.gbfs.GBFSFeedName;
+import org.entur.gbfs.v2_3.gbfs.GBFSFeeds;
+import org.entur.lamassu.cache.GBFSV2FeedCache;
+import org.entur.lamassu.model.provider.FeedProvider;
+import org.entur.lamassu.service.FeedProviderService;
+import org.entur.lamassu.service.SystemDiscoveryService;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.springframework.web.server.ResponseStatusException;
+
+public class GBFSV2FeedControllerTest {
+
+  public static final String KNOWN_SYSTEM_ID = "knownSystem";
+  private GBFSV2FeedController feedController;
+  private FeedProviderService mockedFeedProviderService;
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  private GBFSV2FeedCache mockedFeedCache;
+
+  @Before
+  public void before() {
+    SystemDiscoveryService systemDiscoveryService = mock(SystemDiscoveryService.class);
+    mockedFeedCache = mock(GBFSV2FeedCache.class);
+    mockedFeedProviderService = mock(FeedProviderService.class);
+
+    feedController =
+      new GBFSV2FeedController(
+        systemDiscoveryService,
+        mockedFeedCache,
+        mockedFeedProviderService
+      );
+  }
+
+  @Test
+  public void throws400OnNonGBFSFeedRequest() {
+    expectedException.expect(ResponseStatusException.class);
+    expectedException.expectMessage("400 BAD_REQUEST");
+
+    feedController.getGbfsFeedForProvider("anySystem", "no-gbfs-feed");
+  }
+
+  @Test
+  public void throws404OnNonConfiguredSystemRequest() {
+    expectedException.expect(ResponseStatusException.class);
+    expectedException.expectMessage("404 NOT_FOUND");
+    feedController.getGbfsFeedForProvider("unknownSystem", "gbfs");
+  }
+
+  @Test
+  public void throws502OnConfiguredSystemButUnavailableFeedRequest() {
+    FeedProvider feedProvider = new FeedProvider();
+    feedProvider.setSystemId(KNOWN_SYSTEM_ID);
+    when(mockedFeedProviderService.getFeedProviderBySystemId(KNOWN_SYSTEM_ID))
+      .thenReturn(feedProvider);
+
+    expectedException.expect(ResponseStatusException.class);
+    expectedException.expectMessage("502 BAD_GATEWAY");
+    feedController.getGbfsFeedForProvider(KNOWN_SYSTEM_ID, "gbfs");
+  }
+
+  @Test
+  public void throws404OnConfiguredSystemButUndeclaredFeedRequest() {
+    var feedProvider = new FeedProvider();
+    feedProvider.setSystemId(KNOWN_SYSTEM_ID);
+    var gbfs = createDiscoveryFileWithFeed(GBFSFeedName.GBFS);
+
+    when(mockedFeedProviderService.getFeedProviderBySystemId(KNOWN_SYSTEM_ID))
+      .thenReturn(feedProvider);
+    when(mockedFeedCache.find(GBFSFeedName.GBFS, feedProvider)).thenReturn(gbfs);
+    when(mockedFeedCache.find(GBFSFeedName.GeofencingZones, feedProvider))
+      .thenReturn(null);
+    expectedException.expect(ResponseStatusException.class);
+    expectedException.expectMessage("404 NOT_FOUND");
+    feedController.getGbfsFeedForProvider(KNOWN_SYSTEM_ID, "geofencing_zones");
+  }
+
+  @Test
+  public void throws502OnConfiguredSystemAndDeclaredFeedRequest() {
+    var feedProvider = new FeedProvider();
+    feedProvider.setSystemId(KNOWN_SYSTEM_ID);
+    var gbfs = createDiscoveryFileWithFeed(GBFSFeedName.GeofencingZones);
+
+    when(mockedFeedProviderService.getFeedProviderBySystemId(KNOWN_SYSTEM_ID))
+      .thenReturn(feedProvider);
+    when(mockedFeedCache.find(GBFSFeedName.GBFS, feedProvider)).thenReturn(gbfs);
+    when(mockedFeedCache.find(GBFSFeedName.GeofencingZones, feedProvider))
+      .thenReturn(null);
+    expectedException.expect(ResponseStatusException.class);
+    expectedException.expectMessage("502 BAD_GATEWAY");
+    feedController.getGbfsFeedForProvider(KNOWN_SYSTEM_ID, "geofencing_zones");
+  }
+
+  @Test
+  public void throws502OnConfiguredSystemAndMalformedDiscoveryFeedRequest() {
+    var feedProvider = new FeedProvider();
+    feedProvider.setSystemId(KNOWN_SYSTEM_ID);
+    // GBFS is malformed, as it has no feeds defined
+    var gbfs = new GBFS();
+
+    when(mockedFeedProviderService.getFeedProviderBySystemId(KNOWN_SYSTEM_ID))
+      .thenReturn(feedProvider);
+    when(mockedFeedCache.find(GBFSFeedName.GBFS, feedProvider)).thenReturn(gbfs);
+    when(mockedFeedCache.find(GBFSFeedName.GeofencingZones, feedProvider))
+      .thenReturn(null);
+    expectedException.expect(ResponseStatusException.class);
+    expectedException.expectMessage("502 BAD_GATEWAY");
+    feedController.getGbfsFeedForProvider(KNOWN_SYSTEM_ID, "geofencing_zones");
+  }
+
+  public GBFS createDiscoveryFileWithFeed(GBFSFeedName feedName) {
+    var gbfs = new GBFS();
+    var feeds = new GBFSFeeds();
+    var feed = new GBFSFeed();
+    feed.setName(feedName);
+    feeds.setFeeds(List.of(feed));
+    gbfs.setFeedsData(Map.of("en", feeds));
+    return gbfs;
+  }
+}

--- a/src/test/java/org/entur/lamassu/controller/GBFSV3FeedControllerTest.java
+++ b/src/test/java/org/entur/lamassu/controller/GBFSV3FeedControllerTest.java
@@ -1,0 +1,127 @@
+package org.entur.lamassu.controller;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import org.entur.gbfs.v3_0.gbfs.GBFSData;
+import org.entur.gbfs.v3_0.gbfs.GBFSFeed;
+import org.entur.gbfs.v3_0.gbfs.GBFSGbfs;
+import org.entur.lamassu.cache.GBFSV3FeedCache;
+import org.entur.lamassu.model.provider.FeedProvider;
+import org.entur.lamassu.service.FeedProviderService;
+import org.entur.lamassu.service.SystemDiscoveryService;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.springframework.web.server.ResponseStatusException;
+
+public class GBFSV3FeedControllerTest {
+
+  public static final String KNOWN_SYSTEM_ID = "knownSystem";
+  private GBFSV3FeedController feedController;
+  private FeedProviderService mockedFeedProviderService;
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  private GBFSV3FeedCache mockedFeedCache;
+
+  @Before
+  public void before() {
+    SystemDiscoveryService systemDiscoveryService = mock(SystemDiscoveryService.class);
+    mockedFeedCache = mock(GBFSV3FeedCache.class);
+    mockedFeedProviderService = mock(FeedProviderService.class);
+
+    feedController =
+      new GBFSV3FeedController(
+        systemDiscoveryService,
+        mockedFeedCache,
+        mockedFeedProviderService
+      );
+  }
+
+  @Test
+  public void throws400OnNonGBFSFeedRequest() {
+    expectedException.expect(ResponseStatusException.class);
+    expectedException.expectMessage("400 BAD_REQUEST");
+
+    feedController.getV3Feed("anySystem", "no-gbfs-feed");
+  }
+
+  @Test
+  public void throws404OnNonConfiguredSystemRequest() {
+    expectedException.expect(ResponseStatusException.class);
+    expectedException.expectMessage("404 NOT_FOUND");
+    feedController.getV3Feed("unknownSystem", "gbfs");
+  }
+
+  @Test
+  public void throws502OnConfiguredSystemButUnavailableFeedRequest() {
+    FeedProvider feedProvider = new FeedProvider();
+    feedProvider.setSystemId(KNOWN_SYSTEM_ID);
+    when(mockedFeedProviderService.getFeedProviderBySystemId(KNOWN_SYSTEM_ID))
+      .thenReturn(feedProvider);
+
+    expectedException.expect(UpstreamFeedNotYetAvailableException.class);
+    feedController.getV3Feed(KNOWN_SYSTEM_ID, "gbfs");
+  }
+
+  @Test
+  public void throws404OnConfiguredSystemButUndeclaredFeedRequest() {
+    var feedProvider = new FeedProvider();
+    feedProvider.setSystemId(KNOWN_SYSTEM_ID);
+    var gbfs = createDiscoveryFileWithFeed(GBFSFeed.Name.GBFS);
+
+    when(mockedFeedProviderService.getFeedProviderBySystemId(KNOWN_SYSTEM_ID))
+      .thenReturn(feedProvider);
+    when(mockedFeedCache.find(GBFSFeed.Name.GBFS, feedProvider)).thenReturn(gbfs);
+    when(mockedFeedCache.find(GBFSFeed.Name.GEOFENCING_ZONES, feedProvider))
+      .thenReturn(null);
+    expectedException.expect(ResponseStatusException.class);
+    expectedException.expectMessage("404 NOT_FOUND");
+    feedController.getV3Feed(KNOWN_SYSTEM_ID, "geofencing_zones");
+  }
+
+  @Test
+  public void throws502OnConfiguredSystemAndDeclaredFeedRequest() {
+    var feedProvider = new FeedProvider();
+    feedProvider.setSystemId(KNOWN_SYSTEM_ID);
+    var gbfs = createDiscoveryFileWithFeed(GBFSFeed.Name.GEOFENCING_ZONES);
+
+    when(mockedFeedProviderService.getFeedProviderBySystemId(KNOWN_SYSTEM_ID))
+      .thenReturn(feedProvider);
+    when(mockedFeedCache.find(GBFSFeed.Name.GBFS, feedProvider)).thenReturn(gbfs);
+    when(mockedFeedCache.find(GBFSFeed.Name.GEOFENCING_ZONES, feedProvider))
+      .thenReturn(null);
+    expectedException.expect(UpstreamFeedNotYetAvailableException.class);
+    feedController.getV3Feed(KNOWN_SYSTEM_ID, "geofencing_zones");
+  }
+
+  @Test
+  public void throws502OnConfiguredSystemAndMalformedDiscoveryFeedRequest() {
+    var feedProvider = new FeedProvider();
+    feedProvider.setSystemId(KNOWN_SYSTEM_ID);
+    // GBFS is malformed, as it has no feeds defined
+    var gbfs = new GBFSGbfs();
+
+    when(mockedFeedProviderService.getFeedProviderBySystemId(KNOWN_SYSTEM_ID))
+      .thenReturn(feedProvider);
+    when(mockedFeedCache.find(GBFSFeed.Name.GBFS, feedProvider)).thenReturn(gbfs);
+    when(mockedFeedCache.find(GBFSFeed.Name.GEOFENCING_ZONES, feedProvider))
+      .thenReturn(null);
+    expectedException.expect(UpstreamFeedNotYetAvailableException.class);
+    feedController.getV3Feed(KNOWN_SYSTEM_ID, "geofencing_zones");
+  }
+
+  public GBFSGbfs createDiscoveryFileWithFeed(GBFSFeed.Name feedName) {
+    var gbfs = new GBFSGbfs();
+    var data = new GBFSData();
+    var feed = new GBFSFeed().withName(feedName);
+    data.setFeeds(List.of(feed));
+    gbfs.setData(data);
+    return gbfs;
+  }
+}


### PR DESCRIPTION
### Summary

This PR changes the 404 to an 503 http status code reply when a requested system feed it not found but it's system_id is configured. 

### Issue

Closes #431 .

### Unit tests

Manually verified.
