### PR TITLE
fix: metrics were not registered correctly, this simplifies the setup

### DIFF
--- a/src/main/java/org/entur/lamassu/metrics/MetricsService.java
+++ b/src/main/java/org/entur/lamassu/metrics/MetricsService.java
@@ -54,9 +54,12 @@ public class MetricsService {
   private final AtomicInteger vehicleEntityCount = new AtomicInteger();
   private final AtomicInteger stationEntityCount = new AtomicInteger();
 
-  private final Map<String, AtomicInteger> subscriptionFailedSetupCounters = new ConcurrentHashMap<>();
-  private final Map<String, AtomicInteger> validationFeedErrorsCounters = new ConcurrentHashMap<>();
-  private final Map<String, AtomicInteger> validationMissingRequiredFilesCounters = new ConcurrentHashMap<>();
+  private final Map<String, AtomicInteger> subscriptionFailedSetupCounters =
+    new ConcurrentHashMap<>();
+  private final Map<String, AtomicInteger> validationFeedErrorsCounters =
+    new ConcurrentHashMap<>();
+  private final Map<String, AtomicInteger> validationMissingRequiredFilesCounters =
+    new ConcurrentHashMap<>();
 
   public MetricsService(MeterRegistry meterRegistry) {
     this.meterRegistry = meterRegistry;
@@ -74,8 +77,7 @@ public class MetricsService {
   }
 
   public void registerSubscriptionSetup(FeedProvider feedProvider, boolean success) {
-    getSubscriptionFailedSetupCounter(feedProvider)
-            .set(success ? 0 : 1);
+    getSubscriptionFailedSetupCounter(feedProvider).set(success ? 0 : 1);
   }
 
   public void registerValidationResult(
@@ -83,11 +85,10 @@ public class MetricsService {
     ValidationResult validationResult
   ) {
     getValidationFeedErrorsCounter(feedProvider)
-            .set(validationResult.getSummary().getErrorsCount());
+      .set(validationResult.getSummary().getErrorsCount());
 
     getMissingRequiredFilesCounter(feedProvider)
-            .set(calculateMissingRequiredFiles(validationResult));
-
+      .set(calculateMissingRequiredFiles(validationResult));
   }
 
   public void registerEntityCount(String entity, int entityCount) {
@@ -101,43 +102,61 @@ public class MetricsService {
   }
 
   private AtomicInteger getSubscriptionFailedSetupCounter(FeedProvider feedProvider) {
-    return getCounter(feedProvider, subscriptionFailedSetupCounters, SUBSCRIPTION_FAILEDSETUP);
+    return getCounter(
+      feedProvider,
+      subscriptionFailedSetupCounters,
+      SUBSCRIPTION_FAILEDSETUP
+    );
   }
 
   private AtomicInteger getMissingRequiredFilesCounter(FeedProvider feedProvider) {
-    return getCounter(feedProvider, validationFeedErrorsCounters, VALIDATION_MISSING_REQUIRED_FILES);
+    return getCounter(
+      feedProvider,
+      validationFeedErrorsCounters,
+      VALIDATION_MISSING_REQUIRED_FILES
+    );
   }
 
   private AtomicInteger getValidationFeedErrorsCounter(FeedProvider feedProvider) {
-    return getCounter(feedProvider, validationMissingRequiredFilesCounters, VALIDATION_FEED_ERRORS);
+    return getCounter(
+      feedProvider,
+      validationMissingRequiredFilesCounters,
+      VALIDATION_FEED_ERRORS
+    );
   }
 
-  private AtomicInteger getCounter(FeedProvider feedProvider, Map<String, AtomicInteger> counterMap, String metricName) {
+  private AtomicInteger getCounter(
+    FeedProvider feedProvider,
+    Map<String, AtomicInteger> counterMap,
+    String metricName
+  ) {
     AtomicInteger counter;
     if (counterMap.containsKey(feedProvider.getSystemId())) {
       counter = counterMap.get(feedProvider.getSystemId());
     } else {
       counter = new AtomicInteger();
       counterMap.put(feedProvider.getSystemId(), counter);
-      Gauge.builder(metricName, counter, AtomicInteger::doubleValue)
-              .strongReference(true)
-              .tags(List.of(Tag.of(LABEL_SYSTEM, feedProvider.getSystemId())))
-              .register(meterRegistry);
+      Gauge
+        .builder(metricName, counter, AtomicInteger::doubleValue)
+        .strongReference(true)
+        .tags(List.of(Tag.of(LABEL_SYSTEM, feedProvider.getSystemId())))
+        .register(meterRegistry);
     }
     return counter;
   }
 
   private int calculateMissingRequiredFiles(ValidationResult validationResult) {
     return validationResult
-            .getFiles()
-            .values()
-            .stream().map(fileValidationResult -> {
-              if (fileValidationResult.isRequired() && !fileValidationResult.isExists()) {
-                return 1;
-              } else {
-                return 0;
-              }
-            })
-            .reduce(0, Integer::sum);
+      .getFiles()
+      .values()
+      .stream()
+      .map(fileValidationResult -> {
+        if (fileValidationResult.isRequired() && !fileValidationResult.isExists()) {
+          return 1;
+        } else {
+          return 0;
+        }
+      })
+      .reduce(0, Integer::sum);
   }
 }

--- a/src/main/java/org/entur/lamassu/metrics/MetricsService.java
+++ b/src/main/java/org/entur/lamassu/metrics/MetricsService.java
@@ -22,6 +22,8 @@ import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.entur.gbfs.validation.model.ValidationResult;
 import org.entur.lamassu.model.provider.FeedProvider;
@@ -32,17 +34,13 @@ import org.springframework.stereotype.Component;
 @Component
 public class MetricsService {
 
-  private static final String VALIDATION_MISSING_REQUIRED_FILE =
-    "app.lamassu.gbfs.validation.missingrequiredfile";
-  private static final String VALIDATION_FILE_ERRORS =
-    "app.lamassu.gbfs.validation.fileerrors";
-  private static final String VALIDATION_FEED_ERRORS =
+  protected static final String VALIDATION_MISSING_REQUIRED_FILES =
+    "app.lamassu.gbfs.validation.missingrequiredfiles";
+  protected static final String VALIDATION_FEED_ERRORS =
     "app.lamassu.gbfs.validation.feederrors";
   public static final String LABEL_SYSTEM = "system";
-  public static final String LABEL_VERSION = "version";
-  public static final String LABEL_FILE = "file";
 
-  public static final String SUBSCRIPTION_FAILEDSETUP =
+  protected static final String SUBSCRIPTION_FAILEDSETUP =
     "app.lamassu.gbfs.subscription.failedsetup";
   public static final String LABEL_ENTITY = "entity";
 
@@ -55,6 +53,10 @@ public class MetricsService {
 
   private final AtomicInteger vehicleEntityCount = new AtomicInteger();
   private final AtomicInteger stationEntityCount = new AtomicInteger();
+
+  private final Map<String, AtomicInteger> subscriptionFailedSetupCounters = new ConcurrentHashMap<>();
+  private final Map<String, AtomicInteger> validationFeedErrorsCounters = new ConcurrentHashMap<>();
+  private final Map<String, AtomicInteger> validationMissingRequiredFilesCounters = new ConcurrentHashMap<>();
 
   public MetricsService(MeterRegistry meterRegistry) {
     this.meterRegistry = meterRegistry;
@@ -72,53 +74,20 @@ public class MetricsService {
   }
 
   public void registerSubscriptionSetup(FeedProvider feedProvider, boolean success) {
-    meterRegistry.gauge(
-      SUBSCRIPTION_FAILEDSETUP,
-      List.of(Tag.of(LABEL_SYSTEM, feedProvider.getSystemId())),
-      success ? 0 : 1
-    );
+    getSubscriptionFailedSetupCounter(feedProvider)
+            .set(success ? 0 : 1);
   }
 
   public void registerValidationResult(
     FeedProvider feedProvider,
     ValidationResult validationResult
   ) {
-    meterRegistry.gauge(
-      VALIDATION_FEED_ERRORS,
-      List.of(
-        Tag.of(LABEL_SYSTEM, feedProvider.getSystemId()),
-        Tag.of(LABEL_VERSION, validationResult.getSummary().getVersion())
-      ),
-      validationResult.getSummary().getErrorsCount()
-    );
+    getValidationFeedErrorsCounter(feedProvider)
+            .set(validationResult.getSummary().getErrorsCount());
 
-    validationResult
-      .getFiles()
-      .forEach((file, result) -> {
-        if (result.isRequired()) {
-          meterRegistry.gauge(
-            VALIDATION_MISSING_REQUIRED_FILE,
-            List.of(
-              Tag.of(LABEL_SYSTEM, feedProvider.getSystemId()),
-              Tag.of(LABEL_VERSION, result.getVersion()),
-              Tag.of(LABEL_FILE, file)
-            ),
-            result.isExists() ? 0 : 1
-          );
-        }
+    getMissingRequiredFilesCounter(feedProvider)
+            .set(calculateMissingRequiredFiles(validationResult));
 
-        if (result.isExists()) {
-          meterRegistry.gauge(
-            VALIDATION_FILE_ERRORS,
-            List.of(
-              Tag.of(LABEL_SYSTEM, feedProvider.getSystemId()),
-              Tag.of(LABEL_VERSION, result.getVersion()),
-              Tag.of(LABEL_FILE, file)
-            ),
-            result.getErrorsCount()
-          );
-        }
-      });
   }
 
   public void registerEntityCount(String entity, int entityCount) {
@@ -129,5 +98,46 @@ public class MetricsService {
     } else {
       logger.warn("entity unknown entity={}", entity);
     }
+  }
+
+  private AtomicInteger getSubscriptionFailedSetupCounter(FeedProvider feedProvider) {
+    return getCounter(feedProvider, subscriptionFailedSetupCounters, SUBSCRIPTION_FAILEDSETUP);
+  }
+
+  private AtomicInteger getMissingRequiredFilesCounter(FeedProvider feedProvider) {
+    return getCounter(feedProvider, validationFeedErrorsCounters, VALIDATION_MISSING_REQUIRED_FILES);
+  }
+
+  private AtomicInteger getValidationFeedErrorsCounter(FeedProvider feedProvider) {
+    return getCounter(feedProvider, validationMissingRequiredFilesCounters, VALIDATION_FEED_ERRORS);
+  }
+
+  private AtomicInteger getCounter(FeedProvider feedProvider, Map<String, AtomicInteger> counterMap, String metricName) {
+    AtomicInteger counter;
+    if (counterMap.containsKey(feedProvider.getSystemId())) {
+      counter = counterMap.get(feedProvider.getSystemId());
+    } else {
+      counter = new AtomicInteger();
+      counterMap.put(feedProvider.getSystemId(), counter);
+      Gauge.builder(metricName, counter, AtomicInteger::doubleValue)
+              .strongReference(true)
+              .tags(List.of(Tag.of(LABEL_SYSTEM, feedProvider.getSystemId())))
+              .register(meterRegistry);
+    }
+    return counter;
+  }
+
+  private int calculateMissingRequiredFiles(ValidationResult validationResult) {
+    return validationResult
+            .getFiles()
+            .values()
+            .stream().map(fileValidationResult -> {
+              if (fileValidationResult.isRequired() && !fileValidationResult.isExists()) {
+                return 1;
+              } else {
+                return 0;
+              }
+            })
+            .reduce(0, Integer::sum);
   }
 }

--- a/src/test/java/org/entur/lamassu/metrics/MetricsServiceTest.java
+++ b/src/test/java/org/entur/lamassu/metrics/MetricsServiceTest.java
@@ -18,7 +18,10 @@
 
 package org.entur.lamassu.metrics;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.Map;
 import org.entur.gbfs.validation.model.FileValidationResult;
 import org.entur.gbfs.validation.model.ValidationResult;
 import org.entur.gbfs.validation.model.ValidationSummary;
@@ -26,94 +29,121 @@ import org.entur.lamassu.model.provider.FeedProvider;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 
-import java.util.Map;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 class MetricsServiceTest {
 
-    @Test
-    void testRegisterSubscriptionSetup() {
-        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
-        MetricsService metricsService = new MetricsService(meterRegistry);
-        FeedProvider fp = new FeedProvider();
-        fp.setSystemId("TestSystem");
+  @Test
+  void testRegisterSubscriptionSetup() {
+    SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+    MetricsService metricsService = new MetricsService(meterRegistry);
+    FeedProvider fp = new FeedProvider();
+    fp.setSystemId("TestSystem");
 
-        metricsService.registerSubscriptionSetup(fp, false);
-        assertEquals(1.0, meterRegistry.get(MetricsService.SUBSCRIPTION_FAILEDSETUP).gauge().value(), 0.01);
+    metricsService.registerSubscriptionSetup(fp, false);
+    assertEquals(
+      1.0,
+      meterRegistry.get(MetricsService.SUBSCRIPTION_FAILEDSETUP).gauge().value(),
+      0.01
+    );
 
-        metricsService.registerSubscriptionSetup(fp, true);
-        assertEquals(0.0, meterRegistry.get(MetricsService.SUBSCRIPTION_FAILEDSETUP).gauge().value(), 0.01);
-    }
+    metricsService.registerSubscriptionSetup(fp, true);
+    assertEquals(
+      0.0,
+      meterRegistry.get(MetricsService.SUBSCRIPTION_FAILEDSETUP).gauge().value(),
+      0.01
+    );
+  }
 
-    @Test
-    void testRegisterValidationResult() {
-        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
-        MetricsService metricsService = new MetricsService(meterRegistry);
-        FeedProvider fp = new FeedProvider();
-        fp.setSystemId("TestSystem");
+  @Test
+  void testRegisterValidationResult() {
+    SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+    MetricsService metricsService = new MetricsService(meterRegistry);
+    FeedProvider fp = new FeedProvider();
+    fp.setSystemId("TestSystem");
 
-        metricsService.registerValidationResult(fp, getValidationResult(1));
-        assertEquals(1.0, meterRegistry.get(MetricsService.VALIDATION_FEED_ERRORS).gauge().value(), 0.01);
+    metricsService.registerValidationResult(fp, getValidationResult(1));
+    assertEquals(
+      1.0,
+      meterRegistry.get(MetricsService.VALIDATION_FEED_ERRORS).gauge().value(),
+      0.01
+    );
 
-        metricsService.registerValidationResult(fp, getValidationResult(0));
-        assertEquals(0.0, meterRegistry.get(MetricsService.VALIDATION_FEED_ERRORS).gauge().value(), 0.01);
-    }
+    metricsService.registerValidationResult(fp, getValidationResult(0));
+    assertEquals(
+      0.0,
+      meterRegistry.get(MetricsService.VALIDATION_FEED_ERRORS).gauge().value(),
+      0.01
+    );
+  }
 
-    @Test
-    void testRegisterValidationResultWithMissingRequiredFilse() {
-        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
-        MetricsService metricsService = new MetricsService(meterRegistry);
-        FeedProvider fp = new FeedProvider();
-        fp.setSystemId("TestSystem");
+  @Test
+  void testRegisterValidationResultWithMissingRequiredFilse() {
+    SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+    MetricsService metricsService = new MetricsService(meterRegistry);
+    FeedProvider fp = new FeedProvider();
+    fp.setSystemId("TestSystem");
 
-        metricsService.registerValidationResult(fp, getValidationResultWithMissingRequiredFile());
-        assertEquals(1.0, meterRegistry.get(MetricsService.VALIDATION_FEED_ERRORS).gauge().value(), 0.01);
-        assertEquals(1.0, meterRegistry.get(MetricsService.VALIDATION_MISSING_REQUIRED_FILES).gauge().value(), 0.01);
+    metricsService.registerValidationResult(
+      fp,
+      getValidationResultWithMissingRequiredFile()
+    );
+    assertEquals(
+      1.0,
+      meterRegistry.get(MetricsService.VALIDATION_FEED_ERRORS).gauge().value(),
+      0.01
+    );
+    assertEquals(
+      1.0,
+      meterRegistry.get(MetricsService.VALIDATION_MISSING_REQUIRED_FILES).gauge().value(),
+      0.01
+    );
 
-        metricsService.registerValidationResult(fp, getValidationResult(0));
-        assertEquals(0.0, meterRegistry.get(MetricsService.VALIDATION_FEED_ERRORS).gauge().value(), 0.01);
-        assertEquals(0.0, meterRegistry.get(MetricsService.VALIDATION_MISSING_REQUIRED_FILES).gauge().value(), 0.01);
-    }
+    metricsService.registerValidationResult(fp, getValidationResult(0));
+    assertEquals(
+      0.0,
+      meterRegistry.get(MetricsService.VALIDATION_FEED_ERRORS).gauge().value(),
+      0.01
+    );
+    assertEquals(
+      0.0,
+      meterRegistry.get(MetricsService.VALIDATION_MISSING_REQUIRED_FILES).gauge().value(),
+      0.01
+    );
+  }
 
-    private static @NotNull ValidationResult getValidationResult(int errorCount) {
-        ValidationResult validationResult = new ValidationResult();
-        ValidationSummary validationSummary = new ValidationSummary();
-        validationSummary.setErrorsCount(errorCount);
-        validationSummary.setVersion("3.0");
+  private static @NotNull ValidationResult getValidationResult(int errorCount) {
+    ValidationResult validationResult = new ValidationResult();
+    ValidationSummary validationSummary = new ValidationSummary();
+    validationSummary.setErrorsCount(errorCount);
+    validationSummary.setVersion("3.0");
 
-        FileValidationResult fileValidationResult = new FileValidationResult();
-        fileValidationResult.setFile("gbfs");
-        fileValidationResult.setRequired(true);
-        fileValidationResult.setVersion("3.0");
-        fileValidationResult.setExists(true);
-        fileValidationResult.setErrorsCount(errorCount);
+    FileValidationResult fileValidationResult = new FileValidationResult();
+    fileValidationResult.setFile("gbfs");
+    fileValidationResult.setRequired(true);
+    fileValidationResult.setVersion("3.0");
+    fileValidationResult.setExists(true);
+    fileValidationResult.setErrorsCount(errorCount);
 
-        validationResult.setFiles(Map.of(
-                "gbfs", fileValidationResult
-        ));
+    validationResult.setFiles(Map.of("gbfs", fileValidationResult));
 
-        validationResult.setSummary(validationSummary);
-        return validationResult;
-    }
+    validationResult.setSummary(validationSummary);
+    return validationResult;
+  }
 
-    private static @NotNull ValidationResult getValidationResultWithMissingRequiredFile() {
-        ValidationResult validationResult = new ValidationResult();
-        ValidationSummary validationSummary = new ValidationSummary();
-        validationSummary.setErrorsCount(1);
-        validationSummary.setVersion("3.0");
+  private static @NotNull ValidationResult getValidationResultWithMissingRequiredFile() {
+    ValidationResult validationResult = new ValidationResult();
+    ValidationSummary validationSummary = new ValidationSummary();
+    validationSummary.setErrorsCount(1);
+    validationSummary.setVersion("3.0");
 
-        FileValidationResult fileValidationResult = new FileValidationResult();
-        fileValidationResult.setFile("gbfs");
-        fileValidationResult.setRequired(true);
-        fileValidationResult.setVersion("3.0");
-        fileValidationResult.setExists(false);
+    FileValidationResult fileValidationResult = new FileValidationResult();
+    fileValidationResult.setFile("gbfs");
+    fileValidationResult.setRequired(true);
+    fileValidationResult.setVersion("3.0");
+    fileValidationResult.setExists(false);
 
-        validationResult.setFiles(Map.of(
-                "gbfs", fileValidationResult
-        ));
+    validationResult.setFiles(Map.of("gbfs", fileValidationResult));
 
-        validationResult.setSummary(validationSummary);
-        return validationResult;
-    }
+    validationResult.setSummary(validationSummary);
+    return validationResult;
+  }
 }

--- a/src/test/java/org/entur/lamassu/metrics/MetricsServiceTest.java
+++ b/src/test/java/org/entur/lamassu/metrics/MetricsServiceTest.java
@@ -1,0 +1,119 @@
+/*
+ *
+ *
+ *  * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ *  * the European Commission - subsequent versions of the EUPL (the "Licence");
+ *  * You may not use this work except in compliance with the Licence.
+ *  * You may obtain a copy of the Licence at:
+ *  *
+ *  *   https://joinup.ec.europa.eu/software/page/eupl
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the Licence is distributed on an "AS IS" basis,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the Licence for the specific language governing permissions and
+ *  * limitations under the Licence.
+ *
+ */
+
+package org.entur.lamassu.metrics;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.entur.gbfs.validation.model.FileValidationResult;
+import org.entur.gbfs.validation.model.ValidationResult;
+import org.entur.gbfs.validation.model.ValidationSummary;
+import org.entur.lamassu.model.provider.FeedProvider;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class MetricsServiceTest {
+
+    @Test
+    void testRegisterSubscriptionSetup() {
+        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        MetricsService metricsService = new MetricsService(meterRegistry);
+        FeedProvider fp = new FeedProvider();
+        fp.setSystemId("TestSystem");
+
+        metricsService.registerSubscriptionSetup(fp, false);
+        assertEquals(1.0, meterRegistry.get(MetricsService.SUBSCRIPTION_FAILEDSETUP).gauge().value(), 0.01);
+
+        metricsService.registerSubscriptionSetup(fp, true);
+        assertEquals(0.0, meterRegistry.get(MetricsService.SUBSCRIPTION_FAILEDSETUP).gauge().value(), 0.01);
+    }
+
+    @Test
+    void testRegisterValidationResult() {
+        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        MetricsService metricsService = new MetricsService(meterRegistry);
+        FeedProvider fp = new FeedProvider();
+        fp.setSystemId("TestSystem");
+
+        metricsService.registerValidationResult(fp, getValidationResult(1));
+        assertEquals(1.0, meterRegistry.get(MetricsService.VALIDATION_FEED_ERRORS).gauge().value(), 0.01);
+
+        metricsService.registerValidationResult(fp, getValidationResult(0));
+        assertEquals(0.0, meterRegistry.get(MetricsService.VALIDATION_FEED_ERRORS).gauge().value(), 0.01);
+    }
+
+    @Test
+    void testRegisterValidationResultWithMissingRequiredFilse() {
+        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        MetricsService metricsService = new MetricsService(meterRegistry);
+        FeedProvider fp = new FeedProvider();
+        fp.setSystemId("TestSystem");
+
+        metricsService.registerValidationResult(fp, getValidationResultWithMissingRequiredFile());
+        assertEquals(1.0, meterRegistry.get(MetricsService.VALIDATION_FEED_ERRORS).gauge().value(), 0.01);
+        assertEquals(1.0, meterRegistry.get(MetricsService.VALIDATION_MISSING_REQUIRED_FILES).gauge().value(), 0.01);
+
+        metricsService.registerValidationResult(fp, getValidationResult(0));
+        assertEquals(0.0, meterRegistry.get(MetricsService.VALIDATION_FEED_ERRORS).gauge().value(), 0.01);
+        assertEquals(0.0, meterRegistry.get(MetricsService.VALIDATION_MISSING_REQUIRED_FILES).gauge().value(), 0.01);
+    }
+
+    private static @NotNull ValidationResult getValidationResult(int errorCount) {
+        ValidationResult validationResult = new ValidationResult();
+        ValidationSummary validationSummary = new ValidationSummary();
+        validationSummary.setErrorsCount(errorCount);
+        validationSummary.setVersion("3.0");
+
+        FileValidationResult fileValidationResult = new FileValidationResult();
+        fileValidationResult.setFile("gbfs");
+        fileValidationResult.setRequired(true);
+        fileValidationResult.setVersion("3.0");
+        fileValidationResult.setExists(true);
+        fileValidationResult.setErrorsCount(errorCount);
+
+        validationResult.setFiles(Map.of(
+                "gbfs", fileValidationResult
+        ));
+
+        validationResult.setSummary(validationSummary);
+        return validationResult;
+    }
+
+    private static @NotNull ValidationResult getValidationResultWithMissingRequiredFile() {
+        ValidationResult validationResult = new ValidationResult();
+        ValidationSummary validationSummary = new ValidationSummary();
+        validationSummary.setErrorsCount(1);
+        validationSummary.setVersion("3.0");
+
+        FileValidationResult fileValidationResult = new FileValidationResult();
+        fileValidationResult.setFile("gbfs");
+        fileValidationResult.setRequired(true);
+        fileValidationResult.setVersion("3.0");
+        fileValidationResult.setExists(false);
+
+        validationResult.setFiles(Map.of(
+                "gbfs", fileValidationResult
+        ));
+
+        validationResult.setSummary(validationSummary);
+        return validationResult;
+    }
+}


### PR DESCRIPTION
### Summary

Fixes issues with registering metrics. Metrics are registered once per combination of name and tags - subsequent calls are lost. It is required to keep counters for each combination, which gets hairy. This PR simplifies the setup, removes the file error metrics, and removes version and file tags.

### Issue

Closes #438 

### Unit tests

Unit tests were added to reproduce the problems and verify solution.
