### PR TITLE
Bump serialization version after two PRs that should have done it

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <description>Micro mobility aggregation</description>
 
     <properties>
-        <lamassu.serialization.version.id>18</lamassu.serialization.version.id>
+        <lamassu.serialization.version.id>20</lamassu.serialization.version.id>
 
         <java.version>21</java.version>
 


### PR DESCRIPTION
Both #466 and #450 should have bumped serialization version but I forgot. This PR bumps manually two steps for clarity.
