### PR TITLE
Switch to v3 as base model for entity mapping

### DIFF
--- a/src/main/java/org/entur/lamassu/leader/FeedUpdater.java
+++ b/src/main/java/org/entur/lamassu/leader/FeedUpdater.java
@@ -242,7 +242,7 @@ public class FeedUpdater {
 
       // Configurable maximum history?
       if (validationResults.size() > maxValidationResultsPerSystem) {
-        validationResults.remove(0);
+        validationResults.removeFirst();
       }
     }
   }
@@ -252,10 +252,7 @@ public class FeedUpdater {
       gbfsV2Delivery,
       feedProvider
     );
-    var oldDelivery = v2FeedCachesUpdater.updateFeedCaches(feedProvider, mappedDelivery);
-    if (Boolean.TRUE.equals(feedProvider.getAggregate())) {
-      entityCachesUpdater.updateEntityCaches(feedProvider, mappedDelivery, oldDelivery);
-    }
+    v2FeedCachesUpdater.updateFeedCaches(feedProvider, mappedDelivery);
   }
 
   private void receiveV3Update(FeedProvider feedProvider, GbfsV3Delivery gbfsV3Delivery) {
@@ -263,6 +260,9 @@ public class FeedUpdater {
       gbfsV3Delivery,
       feedProvider
     );
-    v3FeedCachesUpdater.updateFeedCaches(feedProvider, mappedDelivery);
+    var oldDelivery = v3FeedCachesUpdater.updateFeedCaches(feedProvider, mappedDelivery);
+    if (Boolean.TRUE.equals(feedProvider.getAggregate())) {
+      entityCachesUpdater.updateEntityCaches(feedProvider, mappedDelivery, oldDelivery);
+    }
   }
 }

--- a/src/main/java/org/entur/lamassu/leader/entityupdater/EntityCachesUpdater.java
+++ b/src/main/java/org/entur/lamassu/leader/entityupdater/EntityCachesUpdater.java
@@ -18,7 +18,7 @@
 
 package org.entur.lamassu.leader.entityupdater;
 
-import org.entur.gbfs.loader.v2.GbfsV2Delivery;
+import org.entur.gbfs.loader.v3.GbfsV3Delivery;
 import org.entur.lamassu.model.provider.FeedProvider;
 import org.mobilitydata.gbfs.v2_3.gbfs.GBFSFeedName;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,8 +44,8 @@ public class EntityCachesUpdater {
 
   public void updateEntityCaches(
     FeedProvider feedProvider,
-    GbfsV2Delivery delivery,
-    GbfsV2Delivery oldDelivery
+    GbfsV3Delivery delivery,
+    GbfsV3Delivery oldDelivery
   ) {
     if (canUpdateVehicles(delivery, feedProvider)) {
       vehiclesUpdater.addOrUpdateVehicles(feedProvider, delivery, oldDelivery);
@@ -69,7 +69,7 @@ public class EntityCachesUpdater {
     }
   }
 
-  private boolean canUpdateVehicles(GbfsV2Delivery delivery, FeedProvider feedProvider) {
+  private boolean canUpdateVehicles(GbfsV3Delivery delivery, FeedProvider feedProvider) {
     if (
       feedProvider.getExcludeFeeds() != null &&
       feedProvider.getExcludeFeeds().contains(GBFSFeedName.FreeBikeStatus)
@@ -78,8 +78,8 @@ public class EntityCachesUpdater {
     }
 
     return (
-      delivery.freeBikeStatus() != null &&
-      delivery.freeBikeStatus().getData() != null &&
+      delivery.vehicleStatus() != null &&
+      delivery.vehicleStatus().getData() != null &&
       delivery.systemInformation() != null &&
       delivery.systemInformation().getData() != null &&
       delivery.vehicleTypes() != null &&
@@ -89,7 +89,7 @@ public class EntityCachesUpdater {
     );
   }
 
-  private boolean canUpdateStations(GbfsV2Delivery delivery, FeedProvider feedProvider) {
+  private boolean canUpdateStations(GbfsV3Delivery delivery, FeedProvider feedProvider) {
     if (
       feedProvider.getExcludeFeeds() != null &&
       (

--- a/src/main/java/org/entur/lamassu/leader/entityupdater/GeofencingZonesUpdater.java
+++ b/src/main/java/org/entur/lamassu/leader/entityupdater/GeofencingZonesUpdater.java
@@ -25,7 +25,7 @@ import org.entur.lamassu.cache.GeofencingZonesCache;
 import org.entur.lamassu.mapper.entitymapper.GeofencingZonesMapper;
 import org.entur.lamassu.model.provider.FeedProvider;
 import org.entur.lamassu.util.CacheUtil;
-import org.mobilitydata.gbfs.v2_3.geofencing_zones.GBFSGeofencingZones;
+import org.mobilitydata.gbfs.v3_0.geofencing_zones.GBFSGeofencingZones;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -57,7 +57,12 @@ public class GeofencingZonesUpdater {
 
     geofencingZonesCache.updateAll(
       Map.of(mapped.getId(), mapped),
-      CacheUtil.getTtl((int) Instant.now().getEpochSecond(), lastUpdated, ttl, 3600),
+      CacheUtil.getTtl(
+        (int) Instant.now().getEpochSecond(),
+        (int) (lastUpdated.getTime() / 100),
+        ttl,
+        3600
+      ),
       TimeUnit.SECONDS
     );
   }

--- a/src/main/java/org/entur/lamassu/leader/entityupdater/VehicleFilter.java
+++ b/src/main/java/org/entur/lamassu/leader/entityupdater/VehicleFilter.java
@@ -22,11 +22,11 @@ import java.util.Map;
 import java.util.function.Predicate;
 import org.entur.lamassu.model.entities.PricingPlan;
 import org.entur.lamassu.model.entities.VehicleType;
-import org.mobilitydata.gbfs.v2_3.free_bike_status.GBFSBike;
+import org.mobilitydata.gbfs.v3_0.vehicle_status.GBFSVehicle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-class VehicleFilter implements Predicate<GBFSBike> {
+class VehicleFilter implements Predicate<GBFSVehicle> {
 
   private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
@@ -42,7 +42,7 @@ class VehicleFilter implements Predicate<GBFSBike> {
   }
 
   @Override
-  public boolean test(GBFSBike vehicle) {
+  public boolean test(GBFSVehicle vehicle) {
     if (vehicle.getStationId() != null) {
       logger.info("Skipping hybrid-system vehicle {}", vehicle);
       return false;
@@ -55,7 +55,7 @@ class VehicleFilter implements Predicate<GBFSBike> {
       logger.info(
         "Skipping vehicle with unknown pricing plan id {} (vehicle {})",
         vehicle.getPricingPlanId(),
-        vehicle.getBikeId()
+        vehicle.getVehicleId()
       );
       return false;
     }
@@ -64,7 +64,7 @@ class VehicleFilter implements Predicate<GBFSBike> {
       logger.info(
         "Skipping vehicle with unknown vehicle type id {} (vehicle {})",
         vehicle.getVehicleTypeId(),
-        vehicle.getBikeId()
+        vehicle.getVehicleId()
       );
       return false;
     }
@@ -76,7 +76,7 @@ class VehicleFilter implements Predicate<GBFSBike> {
       logger.info(
         "Skipping vehicle without pricing plan id and vehicle type {} without default pricing plan (vehicle {})",
         vehicle.getVehicleTypeId(),
-        vehicle.getBikeId()
+        vehicle.getVehicleId()
       );
       return false;
     }

--- a/src/main/java/org/entur/lamassu/mapper/entitymapper/PricingPlanMapper.java
+++ b/src/main/java/org/entur/lamassu/mapper/entitymapper/PricingPlanMapper.java
@@ -20,12 +20,11 @@ package org.entur.lamassu.mapper.entitymapper;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import org.entur.lamassu.model.entities.PricingPlan;
 import org.entur.lamassu.model.entities.PricingSegment;
-import org.mobilitydata.gbfs.v2_3.system_pricing_plans.GBFSPerKmPricing;
-import org.mobilitydata.gbfs.v2_3.system_pricing_plans.GBFSPerMinPricing;
-import org.mobilitydata.gbfs.v2_3.system_pricing_plans.GBFSPlan;
+import org.mobilitydata.gbfs.v3_0.system_pricing_plans.GBFSPerKmPricing;
+import org.mobilitydata.gbfs.v3_0.system_pricing_plans.GBFSPerMinPricing;
+import org.mobilitydata.gbfs.v3_0.system_pricing_plans.GBFSPlan;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -39,12 +38,33 @@ public class PricingPlanMapper {
     this.translationMapper = translationMapper;
   }
 
-  public PricingPlan mapPricingPlan(GBFSPlan plan, String language) {
+  public PricingPlan mapPricingPlan(GBFSPlan plan) {
     var mapped = new PricingPlan();
     mapped.setId(plan.getPlanId());
-    mapped.setName(translationMapper.mapSingleTranslation(language, plan.getName()));
+    mapped.setName(
+      translationMapper.mapTranslatedString(
+        plan
+          .getName()
+          .stream()
+          .map(name ->
+            translationMapper.mapTranslation(name.getLanguage(), name.getText())
+          )
+          .toList()
+      )
+    );
     mapped.setDescription(
-      translationMapper.mapSingleTranslation(language, plan.getDescription())
+      translationMapper.mapTranslatedString(
+        plan
+          .getDescription()
+          .stream()
+          .map(description ->
+            translationMapper.mapTranslation(
+              description.getLanguage(),
+              description.getText()
+            )
+          )
+          .toList()
+      )
     );
     mapped.setUrl(plan.getUrl());
     mapped.setCurrency(plan.getCurrency());
@@ -72,7 +92,7 @@ public class PricingPlanMapper {
               pricingSegment.getEnd()
             )
           )
-          .collect(Collectors.toList())
+          .toList()
       );
   }
 
@@ -92,7 +112,7 @@ public class PricingPlanMapper {
               pricingSegment.getEnd()
             )
           )
-          .collect(Collectors.toList())
+          .toList()
       );
   }
 

--- a/src/main/java/org/entur/lamassu/mapper/entitymapper/RentalUrisMapper.java
+++ b/src/main/java/org/entur/lamassu/mapper/entitymapper/RentalUrisMapper.java
@@ -19,7 +19,7 @@
 package org.entur.lamassu.mapper.entitymapper;
 
 import org.entur.lamassu.model.entities.RentalUris;
-import org.mobilitydata.gbfs.v2_3.free_bike_status.GBFSRentalUris;
+import org.mobilitydata.gbfs.v3_0.vehicle_status.GBFSRentalUris;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -38,7 +38,7 @@ public class RentalUrisMapper {
   }
 
   public RentalUris mapRentalUris(
-    org.mobilitydata.gbfs.v2_3.station_information.GBFSRentalUris rentalUris
+    org.mobilitydata.gbfs.v3_0.station_information.GBFSRentalUris rentalUris
   ) {
     if (rentalUris == null) {
       return null;

--- a/src/main/java/org/entur/lamassu/mapper/entitymapper/SystemDiscoveryMapper.java
+++ b/src/main/java/org/entur/lamassu/mapper/entitymapper/SystemDiscoveryMapper.java
@@ -21,7 +21,7 @@ package org.entur.lamassu.mapper.entitymapper;
 import org.entur.lamassu.model.discovery.System;
 import org.entur.lamassu.model.provider.FeedProvider;
 import org.entur.lamassu.util.FeedUrlUtil;
-import org.mobilitydata.gbfs.v2_3.gbfs.GBFSFeedName;
+import org.mobilitydata.gbfs.v3_0.gbfs.GBFSFeed;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -34,9 +34,7 @@ public class SystemDiscoveryMapper {
   public System mapSystemDiscovery(FeedProvider feedProvider) {
     var mapped = new System();
     mapped.setId(feedProvider.getSystemId());
-    mapped.setUrl(
-      FeedUrlUtil.mapFeedUrl(baseUrl, GBFSFeedName.GBFS, feedProvider).toString()
-    );
+    mapped.setUrl(FeedUrlUtil.mapFeedUrl(baseUrl, GBFSFeed.Name.GBFS, feedProvider));
     return mapped;
   }
 }

--- a/src/main/java/org/entur/lamassu/mapper/entitymapper/VehicleMapper.java
+++ b/src/main/java/org/entur/lamassu/mapper/entitymapper/VehicleMapper.java
@@ -19,13 +19,12 @@
 package org.entur.lamassu.mapper.entitymapper;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import org.entur.lamassu.model.entities.PricingPlan;
 import org.entur.lamassu.model.entities.System;
 import org.entur.lamassu.model.entities.Vehicle;
 import org.entur.lamassu.model.entities.VehicleEquipment;
 import org.entur.lamassu.model.entities.VehicleType;
-import org.mobilitydata.gbfs.v2_3.free_bike_status.GBFSBike;
+import org.mobilitydata.gbfs.v3_0.vehicle_status.GBFSVehicle;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -40,30 +39,30 @@ public class VehicleMapper {
   }
 
   public Vehicle mapVehicle(
-    GBFSBike bike,
+    GBFSVehicle vehicle,
     VehicleType vehicleType,
     PricingPlan pricingPlan,
     System system
   ) {
-    var vehicle = new Vehicle();
-    vehicle.setId(bike.getBikeId());
-    vehicle.setLat(bike.getLat());
-    vehicle.setLon(bike.getLon());
-    vehicle.setReserved(bike.getIsReserved());
-    vehicle.setDisabled(bike.getIsDisabled());
-    vehicle.setCurrentRangeMeters(bike.getCurrentRangeMeters());
-    vehicle.setCurrentFuelPercent(bike.getCurrentFuelPercent());
-    vehicle.setVehicleType(vehicleType);
-    vehicle.setPricingPlan(pricingPlan);
-    vehicle.setVehicleEquipment(mapVehicleEquipment(bike.getVehicleEquipment()));
-    vehicle.setRentalUris(rentalUrisMapper.mapRentalUris(bike.getRentalUris()));
-    vehicle.setAvailableUntil(bike.getAvailableUntil());
-    vehicle.setSystem(system);
-    return vehicle;
+    var mappedVehicle = new Vehicle();
+    mappedVehicle.setId(vehicle.getVehicleId());
+    mappedVehicle.setLat(vehicle.getLat());
+    mappedVehicle.setLon(vehicle.getLon());
+    mappedVehicle.setReserved(vehicle.getIsReserved());
+    mappedVehicle.setDisabled(vehicle.getIsDisabled());
+    mappedVehicle.setCurrentRangeMeters(vehicle.getCurrentRangeMeters());
+    mappedVehicle.setCurrentFuelPercent(vehicle.getCurrentFuelPercent());
+    mappedVehicle.setVehicleType(vehicleType);
+    mappedVehicle.setPricingPlan(pricingPlan);
+    mappedVehicle.setVehicleEquipment(mapVehicleEquipment(vehicle.getVehicleEquipment()));
+    mappedVehicle.setRentalUris(rentalUrisMapper.mapRentalUris(vehicle.getRentalUris()));
+    mappedVehicle.setAvailableUntil(vehicle.getAvailableUntil());
+    mappedVehicle.setSystem(system);
+    return mappedVehicle;
   }
 
   private List<VehicleEquipment> mapVehicleEquipment(
-    List<org.mobilitydata.gbfs.v2_3.free_bike_status.VehicleEquipment> vehicleEquipment
+    List<org.mobilitydata.gbfs.v3_0.vehicle_status.VehicleEquipment> vehicleEquipment
   ) {
     if (vehicleEquipment == null) {
       return null;
@@ -74,6 +73,6 @@ public class VehicleMapper {
       .map(vehicleEquipmentEnum ->
         VehicleEquipment.valueOf(vehicleEquipmentEnum.value().toUpperCase())
       )
-      .collect(Collectors.toList());
+      .toList();
   }
 }

--- a/src/main/java/org/entur/lamassu/model/entities/VehicleTypeCapacity.java
+++ b/src/main/java/org/entur/lamassu/model/entities/VehicleTypeCapacity.java
@@ -19,10 +19,14 @@
 package org.entur.lamassu.model.entities;
 
 import java.io.Serializable;
+import java.util.List;
 
 public class VehicleTypeCapacity implements Serializable {
 
   private VehicleType vehicleType;
+
+  private List<VehicleType> vehicleTypes;
+
   private Integer count;
 
   public VehicleType getVehicleType() {
@@ -31,6 +35,14 @@ public class VehicleTypeCapacity implements Serializable {
 
   public void setVehicleType(VehicleType vehicleType) {
     this.vehicleType = vehicleType;
+  }
+
+  public List<VehicleType> getVehicleTypes() {
+    return vehicleTypes;
+  }
+
+  public void setVehicleTypes(List<VehicleType> vehicleTypes) {
+    this.vehicleTypes = vehicleTypes;
   }
 
   public Integer getCount() {

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -321,7 +321,8 @@ type Operator {
 }
 
 type VehicleTypeCapacity {
-    vehicleType: VehicleType!
+    vehicleType: VehicleType! @deprecated(reason: "Use vehicleTypes instead")
+    vehicleTypes: [VehicleType!]!
     count: Int!
 }
 

--- a/src/test/java/org/entur/lamassu/leader/entityupdater/VehicleFilterTest.java
+++ b/src/test/java/org/entur/lamassu/leader/entityupdater/VehicleFilterTest.java
@@ -4,7 +4,7 @@ import java.util.HashMap;
 import org.entur.lamassu.model.entities.PricingPlan;
 import org.entur.lamassu.model.entities.VehicleType;
 import org.junit.Test;
-import org.mobilitydata.gbfs.v2_3.free_bike_status.GBFSBike;
+import org.mobilitydata.gbfs.v3_0.vehicle_status.GBFSVehicle;
 
 public class VehicleFilterTest {
 
@@ -28,8 +28,8 @@ public class VehicleFilterTest {
       vehicleTypesWithPricingPlan(new PricingPlan())
     );
 
-    GBFSBike vehicle = new GBFSBike();
-    vehicle.setBikeId("VehicleWithoutPricingPlan");
+    GBFSVehicle vehicle = new GBFSVehicle();
+    vehicle.setVehicleId("VehicleWithoutPricingPlan");
     vehicle.setVehicleTypeId("vehicleTypeId");
 
     assert filter.test(vehicle) == true;
@@ -42,8 +42,8 @@ public class VehicleFilterTest {
       vehicleTypesWithPricingPlan(null)
     );
 
-    GBFSBike vehicle = new GBFSBike();
-    vehicle.setBikeId("VehicleWithoutPricingPlan");
+    GBFSVehicle vehicle = new GBFSVehicle();
+    vehicle.setVehicleId("VehicleWithoutPricingPlan");
     vehicle.setVehicleTypeId("vehicleTypeId");
 
     assert filter.test(vehicle) == false;


### PR DESCRIPTION
### Summary

Switching to GBFS v3 as the base for entity mapping enables us to expose new gbfs features in graphql api (see #412)

### Issue

Closes #457 

### Tests

There is decent automated test coverage for this change, but I've also done some manual testing with your production feeds.
