### PR TITLE
fix: incorrect urls generated for system discovery (v2)

### DIFF
--- a/src/main/java/org/entur/lamassu/mapper/entitymapper/SystemDiscoveryMapper.java
+++ b/src/main/java/org/entur/lamassu/mapper/entitymapper/SystemDiscoveryMapper.java
@@ -21,7 +21,7 @@ package org.entur.lamassu.mapper.entitymapper;
 import org.entur.lamassu.model.discovery.System;
 import org.entur.lamassu.model.provider.FeedProvider;
 import org.entur.lamassu.util.FeedUrlUtil;
-import org.mobilitydata.gbfs.v3_0.gbfs.GBFSFeed;
+import org.mobilitydata.gbfs.v2_3.gbfs.GBFSFeedName;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -34,7 +34,9 @@ public class SystemDiscoveryMapper {
   public System mapSystemDiscovery(FeedProvider feedProvider) {
     var mapped = new System();
     mapped.setId(feedProvider.getSystemId());
-    mapped.setUrl(FeedUrlUtil.mapFeedUrl(baseUrl, GBFSFeed.Name.GBFS, feedProvider));
+    mapped.setUrl(
+      FeedUrlUtil.mapFeedUrl(baseUrl, GBFSFeedName.GBFS, feedProvider).toString()
+    );
     return mapped;
   }
 }


### PR DESCRIPTION
### Summary

During refactoring, a regression was introduced which generated v3beta urls for v2 system discovery. This PR fixes that regression by calling the correct method overload.
