### PR TITLE
Map current_range_meters as provided instead of setting a missing value to 0.0

### DIFF
--- a/src/main/java/org/entur/lamassu/mapper/entitymapper/VehicleMapper.java
+++ b/src/main/java/org/entur/lamassu/mapper/entitymapper/VehicleMapper.java
@@ -50,7 +50,9 @@ public class VehicleMapper {
     mappedVehicle.setLon(vehicle.getLon());
     mappedVehicle.setReserved(vehicle.getIsReserved());
     mappedVehicle.setDisabled(vehicle.getIsDisabled());
-    mappedVehicle.setCurrentRangeMeters(vehicle.getCurrentRangeMeters());
+    mappedVehicle.setCurrentRangeMeters(
+      vehicle.getCurrentRangeMeters() == null ? 0.0 : vehicle.getCurrentRangeMeters()
+    );
     mappedVehicle.setCurrentFuelPercent(vehicle.getCurrentFuelPercent());
     mappedVehicle.setVehicleType(vehicleType);
     mappedVehicle.setPricingPlan(pricingPlan);

--- a/src/main/java/org/entur/lamassu/mapper/feedmapper/v2/FreeBikeStatusFeedMapper.java
+++ b/src/main/java/org/entur/lamassu/mapper/feedmapper/v2/FreeBikeStatusFeedMapper.java
@@ -80,9 +80,7 @@ public class FreeBikeStatusFeedMapper extends AbstractFeedMapper<GBFSFreeBikeSta
     mapped.setRentalUris(bike.getRentalUris());
     mapped.setVehicleTypeId(mapVehicleTypeId(bike.getVehicleTypeId(), feedProvider));
     mapped.setLastReported(bike.getLastReported());
-    mapped.setCurrentRangeMeters(
-      bike.getCurrentRangeMeters() != null ? bike.getCurrentRangeMeters() : 0
-    );
+    mapped.setCurrentRangeMeters(bike.getCurrentRangeMeters());
     mapped.setCurrentFuelPercent(bike.getCurrentFuelPercent());
     mapped.setStationId(mapStationId(bike.getStationId(), feedProvider));
     mapped.setHomeStationId(mapStationId(bike.getHomeStationId(), feedProvider));

--- a/src/main/java/org/entur/lamassu/mapper/feedmapper/v3/VehicleStatusFeedMapper.java
+++ b/src/main/java/org/entur/lamassu/mapper/feedmapper/v3/VehicleStatusFeedMapper.java
@@ -78,9 +78,7 @@ public class VehicleStatusFeedMapper extends AbstractFeedMapper<GBFSVehicleStatu
     mapped.setRentalUris(vehicle.getRentalUris());
     mapped.setVehicleTypeId(mapVehicleTypeId(vehicle.getVehicleTypeId(), feedProvider));
     mapped.setLastReported(vehicle.getLastReported());
-    mapped.setCurrentRangeMeters(
-      vehicle.getCurrentRangeMeters() != null ? vehicle.getCurrentRangeMeters() : 0
-    );
+    mapped.setCurrentRangeMeters(vehicle.getCurrentRangeMeters());
     mapped.setCurrentFuelPercent(vehicle.getCurrentFuelPercent());
     mapped.setStationId(mapStationId(vehicle.getStationId(), feedProvider));
     mapped.setHomeStationId(mapStationId(vehicle.getHomeStationId(), feedProvider));

--- a/src/test/java/org/entur/lamassu/mapper/feedmapper/v2/FreeBikeStatusFeedMapperTest.java
+++ b/src/test/java/org/entur/lamassu/mapper/feedmapper/v2/FreeBikeStatusFeedMapperTest.java
@@ -41,7 +41,8 @@ class FreeBikeStatusFeedMapperTest {
   void testMissingCurrentRangeMeters() {
     var feedProvider = getTestProvider();
     var mapped = mapper.mapBike(new GBFSBike(), feedProvider);
-    Assertions.assertNotNull(mapped.getCurrentRangeMeters());
+    // if no current_range_meters is provided, we explicitly don't want Lamassu to fill it in
+    Assertions.assertNull(mapped.getCurrentRangeMeters());
   }
 
   @Test


### PR DESCRIPTION
### Summary

This PR maps a vehicle's `current_range_meters` as provided. A missing value is not set to a default of `0`, which would only be appropriate, if the vehicle_type's propulsion_type was not `human`. 

### Issue
Closes #502

### Unit tests

This PR updates `FreeBikeStatusFeedMapperTest.testMissingCurrentRangeMeters` to explicitly check, that missing `current_range_meters` is not filled in. While the test suggests an easy fix to just check the vehicle_type's propulsion_type by accessing it from `feedProvider.getVehicleTypes()`, this is usually not populated for harvested feeds, but would need explicit configuration.