### PR TITLE
Improve exception handling during subscription update

### DIFF
--- a/src/main/java/org/entur/lamassu/leader/LamassuUpdaterException.java
+++ b/src/main/java/org/entur/lamassu/leader/LamassuUpdaterException.java
@@ -1,0 +1,35 @@
+/*
+ *
+ *
+ *  * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ *  * the European Commission - subsequent versions of the EUPL (the "Licence");
+ *  * You may not use this work except in compliance with the Licence.
+ *  * You may obtain a copy of the Licence at:
+ *  *
+ *  *   https://joinup.ec.europa.eu/software/page/eupl
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the Licence is distributed on an "AS IS" basis,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the Licence for the specific language governing permissions and
+ *  * limitations under the Licence.
+ *
+ */
+
+package org.entur.lamassu.leader;
+
+import org.entur.lamassu.model.provider.FeedProvider;
+
+public class LamassuUpdaterException extends RuntimeException {
+
+  private final FeedProvider feedProvider;
+
+  public LamassuUpdaterException(FeedProvider feedProvider, Exception cause) {
+    super(cause);
+    this.feedProvider = feedProvider;
+  }
+
+  public FeedProvider getFeedProvider() {
+    return feedProvider;
+  }
+}


### PR DESCRIPTION
### Summary

The purpose of this PR is to retain feedprovider info when exceptions occur during subscription update, so we can produce better logging.

### Issue

Relates to #250 
