### PR TITLE
Add subscription update interceptor to add systemId to update logs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <okhttp.version>4.12.0</okhttp.version>
         <kryo.version>5.6.0</kryo.version>
         <jackson.version>2.17.2</jackson.version>
-        <gbfs-loader-java.version>4.0.10</gbfs-loader-java.version>
+        <gbfs-loader-java.version>4.0.11</gbfs-loader-java.version>
         <gbfs-validator-java.version>2.0.7</gbfs-validator-java.version>
         <gbfs-mapper-java.version>2.0.8</gbfs-mapper-java.version>
         <prettier-java.version>2.1.0</prettier-java.version>

--- a/src/main/java/org/entur/lamassu/leader/FeedUpdater.java
+++ b/src/main/java/org/entur/lamassu/leader/FeedUpdater.java
@@ -136,6 +136,8 @@ public class FeedUpdater {
       enableValidation
     );
 
+    var interceptor = new LoggingSubscriptionUpdateInterceptor(feedProvider);
+
     String id;
 
     if (feedProvider.getVersion() != null && feedProvider.getVersion().startsWith("3")) {
@@ -150,7 +152,8 @@ public class FeedUpdater {
             );
             receiveV3Update(feedProvider, gbfsV3Delivery);
             cacheReady.set(true);
-          }
+          },
+          interceptor
         );
     } else {
       id =
@@ -164,7 +167,8 @@ public class FeedUpdater {
               GbfsFeedVersionMappers.map(gbfsV2Delivery, feedProvider.getLanguage())
             );
             cacheReady.set(true);
-          }
+          },
+          interceptor
         );
     }
 

--- a/src/main/java/org/entur/lamassu/leader/LoggingSubscriptionUpdateInterceptor.java
+++ b/src/main/java/org/entur/lamassu/leader/LoggingSubscriptionUpdateInterceptor.java
@@ -22,21 +22,22 @@ import org.entur.gbfs.SubscriptionUpdateInterceptor;
 import org.entur.lamassu.model.provider.FeedProvider;
 import org.slf4j.MDC;
 
-public class LoggingSubscriptionUpdateInterceptor implements SubscriptionUpdateInterceptor {
-    private final FeedProvider feedProvider;
+public class LoggingSubscriptionUpdateInterceptor
+  implements SubscriptionUpdateInterceptor {
 
-    public LoggingSubscriptionUpdateInterceptor(
-            FeedProvider feedProvider
-    ) {
-        this.feedProvider = feedProvider;
-    }
-    @Override
-    public void beforeUpdate() {
-        MDC.put("systemId", feedProvider.getSystemId());
-    }
+  private final FeedProvider feedProvider;
 
-    @Override
-    public void afterUpdate() {
-        MDC.remove("systemId");
-    }
+  public LoggingSubscriptionUpdateInterceptor(FeedProvider feedProvider) {
+    this.feedProvider = feedProvider;
+  }
+
+  @Override
+  public void beforeUpdate() {
+    MDC.put("systemId", feedProvider.getSystemId());
+  }
+
+  @Override
+  public void afterUpdate() {
+    MDC.remove("systemId");
+  }
 }

--- a/src/main/java/org/entur/lamassu/leader/LoggingSubscriptionUpdateInterceptor.java
+++ b/src/main/java/org/entur/lamassu/leader/LoggingSubscriptionUpdateInterceptor.java
@@ -1,0 +1,42 @@
+/*
+ *
+ *
+ *  * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ *  * the European Commission - subsequent versions of the EUPL (the "Licence");
+ *  * You may not use this work except in compliance with the Licence.
+ *  * You may obtain a copy of the Licence at:
+ *  *
+ *  *   https://joinup.ec.europa.eu/software/page/eupl
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the Licence is distributed on an "AS IS" basis,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the Licence for the specific language governing permissions and
+ *  * limitations under the Licence.
+ *
+ */
+
+package org.entur.lamassu.leader;
+
+import org.entur.gbfs.SubscriptionUpdateInterceptor;
+import org.entur.lamassu.model.provider.FeedProvider;
+import org.slf4j.MDC;
+
+public class LoggingSubscriptionUpdateInterceptor implements SubscriptionUpdateInterceptor {
+    private final FeedProvider feedProvider;
+
+    public LoggingSubscriptionUpdateInterceptor(
+            FeedProvider feedProvider
+    ) {
+        this.feedProvider = feedProvider;
+    }
+    @Override
+    public void beforeUpdate() {
+        MDC.put("systemId", feedProvider.getSystemId());
+    }
+
+    @Override
+    public void afterUpdate() {
+        MDC.remove("systemId");
+    }
+}

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -30,6 +30,9 @@
                                     "serviceContext": {
                                         "service": "lamassu"
                                     },
+                                    "mdc": {
+                                        "systemId": "%X{systemId}"
+                                    },
                                     "message": "%message\n%ex{full}",
                                     "severity": "%level",
                                     "reportLocation": {


### PR DESCRIPTION
## PR Instructions

### Summary

The gbfs-loader library has some useful logging, but lack context of feedprovider / system. This PR adds an interceptor to subscriptions so systemId can be added to mapped diagnostics context (mdc).

Depends on https://github.com/entur/gbfs-loader-java/pull/179

### Issue

Closes #250. #514 should still be considered as a way to improve handling of those exceptions that are not caught in the library?
