### PR TITLE
Add bounding box search functionality to vehicles and stations queries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,6 +207,11 @@
             <artifactId>mapbox-sdk-geojson</artifactId>
             <version>5.8.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-main</artifactId>
+            <version>31.3</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -356,4 +361,21 @@
             </build>
         </profile>
     </profiles>
+
+    <repositories>
+        <repository>
+            <id>osgeo</id>
+            <name>OSGeo Release Repository</name>
+            <url>https://repo.osgeo.org/repository/release/</url>
+            <snapshots><enabled>false</enabled></snapshots>
+            <releases><enabled>true</enabled></releases>
+        </repository>
+        <repository>
+            <id>osgeo-snapshot</id>
+            <name>OSGeo Snapshot Repository</name>
+            <url>https://repo.osgeo.org/repository/snapshot/</url>
+            <snapshots><enabled>true</enabled></snapshots>
+            <releases><enabled>false</enabled></releases>
+        </repository>
+    </repositories>
 </project>

--- a/src/main/java/org/entur/lamassu/controller/GraphQLQueryController.java
+++ b/src/main/java/org/entur/lamassu/controller/GraphQLQueryController.java
@@ -93,7 +93,6 @@ public class GraphQLQueryController implements GraphQLQueryResolver {
     queryParams.setLat(lat);
     queryParams.setLon(lon);
     queryParams.setRange(range);
-    queryParams.setCount(count);
 
     var filterParams = new VehicleFilterParameters();
     filterParams.setCodespaces(codespaces);
@@ -103,6 +102,7 @@ public class GraphQLQueryController implements GraphQLQueryResolver {
     filterParams.setPropulsionTypes(propulsionTypes);
     filterParams.setIncludeReserved(includeReserved);
     filterParams.setIncludeDisabled(includeDisabled);
+    filterParams.setCount(count);
 
     logger.debug("getVehicles called query={} filter={}", queryParams, filterParams);
 
@@ -138,7 +138,6 @@ public class GraphQLQueryController implements GraphQLQueryResolver {
     queryParams.setLat(lat);
     queryParams.setLon(lon);
     queryParams.setRange(range);
-    queryParams.setCount(count);
 
     var filterParams = new StationFilterParameters();
     filterParams.setCodespaces(codespaces);
@@ -146,6 +145,7 @@ public class GraphQLQueryController implements GraphQLQueryResolver {
     filterParams.setOperators(operators);
     filterParams.setAvailableFormFactors(availableFormFactors);
     filterParams.setAvailablePropulsionTypes(availablePropulsionTypes);
+    filterParams.setCount(count);
 
     logger.debug("getStations called query={} filter={}", queryParams, filterParams);
 

--- a/src/main/java/org/entur/lamassu/controller/GraphQLQueryController.java
+++ b/src/main/java/org/entur/lamassu/controller/GraphQLQueryController.java
@@ -106,7 +106,7 @@ public class GraphQLQueryController implements GraphQLQueryResolver {
 
     logger.debug("getVehicles called query={} filter={}", queryParams, filterParams);
 
-    return geoSearchService.getVehiclesNearby(queryParams, filterParams);
+    return geoSearchService.getVehiclesWithinRange(queryParams, filterParams);
   }
 
   public Vehicle getVehicle(String id) {
@@ -149,7 +149,7 @@ public class GraphQLQueryController implements GraphQLQueryResolver {
 
     logger.debug("getStations called query={} filter={}", queryParams, filterParams);
 
-    return geoSearchService.getStationsNearby(queryParams, filterParams);
+    return geoSearchService.getStationsWithinRange(queryParams, filterParams);
   }
 
   public Station getStation(String id) {

--- a/src/main/java/org/entur/lamassu/controller/GraphQLQueryController.java
+++ b/src/main/java/org/entur/lamassu/controller/GraphQLQueryController.java
@@ -18,6 +18,7 @@ import org.entur.lamassu.model.entities.PropulsionType;
 import org.entur.lamassu.model.entities.Station;
 import org.entur.lamassu.model.entities.Vehicle;
 import org.entur.lamassu.model.provider.FeedProvider;
+import org.entur.lamassu.service.BoundingBoxQueryParameters;
 import org.entur.lamassu.service.FeedProviderService;
 import org.entur.lamassu.service.GeoSearchService;
 import org.entur.lamassu.service.RangeQueryParameters;
@@ -71,6 +72,10 @@ public class GraphQLQueryController implements GraphQLQueryResolver {
     Double lat,
     Double lon,
     Double range,
+    Double minimumLatitude,
+    Double minimumLongitude,
+    Double maximumLatitude,
+    Double maximumLongitude,
     Integer count,
     List<String> codespaces,
     List<String> systems,
@@ -84,15 +89,9 @@ public class GraphQLQueryController implements GraphQLQueryResolver {
       return vehicleCache.getAll(ids);
     }
 
-    validateRange(range);
     validateCount(count);
     validateCodespaces(codespaces);
     validateSystems(systems);
-
-    var queryParams = new RangeQueryParameters();
-    queryParams.setLat(lat);
-    queryParams.setLon(lon);
-    queryParams.setRange(range);
 
     var filterParams = new VehicleFilterParameters();
     filterParams.setCodespaces(codespaces);
@@ -104,9 +103,53 @@ public class GraphQLQueryController implements GraphQLQueryResolver {
     filterParams.setIncludeDisabled(includeDisabled);
     filterParams.setCount(count);
 
-    logger.debug("getVehicles called query={} filter={}", queryParams, filterParams);
+    if (
+      isBoundingBoxSearch(
+        minimumLatitude,
+        minimumLongitude,
+        maximumLatitude,
+        maximumLongitude
+      )
+    ) {
+      var boundingBoxQueryParameters = new BoundingBoxQueryParameters();
+      boundingBoxQueryParameters.setMinimumLatitude(minimumLatitude);
+      boundingBoxQueryParameters.setMinimumLongitude(minimumLongitude);
+      boundingBoxQueryParameters.setMaximumLatitude(maximumLatitude);
+      boundingBoxQueryParameters.setMaximumLongitude(maximumLongitude);
 
-    return geoSearchService.getVehiclesWithinRange(queryParams, filterParams);
+      logger.debug(
+        "getVehicles called boundingBoxQueryParameters={} filter={}",
+        boundingBoxQueryParameters,
+        filterParams
+      );
+
+      return geoSearchService.getVehiclesInBoundingBox(
+        boundingBoxQueryParameters,
+        filterParams
+      );
+    } else if (range != null && lat != null && lon != null) {
+      // add conditional to verify range search
+      validateRange(range);
+
+      var rangeQueryParameters = new RangeQueryParameters();
+      rangeQueryParameters.setLat(lat);
+      rangeQueryParameters.setLon(lon);
+      rangeQueryParameters.setRange(range);
+
+      logger.debug(
+        "getVehicles called rangeQueryParameters={} filter={}",
+        rangeQueryParameters,
+        filterParams
+      );
+
+      return geoSearchService.getVehiclesWithinRange(rangeQueryParameters, filterParams);
+    } else {
+      throw new GraphqlErrorException.Builder()
+        .message(
+          "You must either specify lat, lon and range OR minimumLatitude, minimumLongitude, maximumLatitude and maximumLongitude"
+        )
+        .build();
+    }
   }
 
   public Vehicle getVehicle(String id) {
@@ -118,6 +161,10 @@ public class GraphQLQueryController implements GraphQLQueryResolver {
     Double lat,
     Double lon,
     Double range,
+    Double minimumLatitude,
+    Double minimumLongitude,
+    Double maximumLatitude,
+    Double maximumLongitude,
     Integer count,
     List<String> codespaces,
     List<String> systems,
@@ -129,15 +176,9 @@ public class GraphQLQueryController implements GraphQLQueryResolver {
       return stationCache.getAll(ids);
     }
 
-    validateRange(range);
     validateCount(count);
     validateCodespaces(codespaces);
     validateSystems(systems);
-
-    var queryParams = new RangeQueryParameters();
-    queryParams.setLat(lat);
-    queryParams.setLon(lon);
-    queryParams.setRange(range);
 
     var filterParams = new StationFilterParameters();
     filterParams.setCodespaces(codespaces);
@@ -147,9 +188,66 @@ public class GraphQLQueryController implements GraphQLQueryResolver {
     filterParams.setAvailablePropulsionTypes(availablePropulsionTypes);
     filterParams.setCount(count);
 
-    logger.debug("getStations called query={} filter={}", queryParams, filterParams);
+    if (
+      isBoundingBoxSearch(
+        minimumLatitude,
+        minimumLongitude,
+        maximumLatitude,
+        maximumLongitude
+      )
+    ) {
+      // TODO validate params, e.g.  [(170,60), (-170,70)]
+      var boundingBoxQueryParameters = new BoundingBoxQueryParameters();
+      boundingBoxQueryParameters.setMinimumLatitude(minimumLatitude);
+      boundingBoxQueryParameters.setMinimumLongitude(minimumLongitude);
+      boundingBoxQueryParameters.setMaximumLatitude(maximumLatitude);
+      boundingBoxQueryParameters.setMaximumLongitude(maximumLongitude);
+      logger.debug(
+        "getStations called boundingBoxQueryParameters={} filter={}",
+        boundingBoxQueryParameters,
+        filterParams
+      );
+      return geoSearchService.getStationsInBoundingBox(
+        boundingBoxQueryParameters,
+        filterParams
+      );
+    } else if (isRangeSearch(range, lat, lon)) {
+      validateRange(range);
+      var rangeQueryParameters = new RangeQueryParameters();
+      rangeQueryParameters.setLat(lat);
+      rangeQueryParameters.setLon(lon);
+      rangeQueryParameters.setRange(range);
+      logger.debug(
+        "getStations called rangeQueryParameters={} filter={}",
+        rangeQueryParameters,
+        filterParams
+      );
+      return geoSearchService.getStationsWithinRange(rangeQueryParameters, filterParams);
+    } else {
+      throw new GraphqlErrorException.Builder()
+        .message(
+          "You must either specify lat, lon and range OR minimumLatitude, minimumLongitude, maximumLatitude and maximumLongitude"
+        )
+        .build();
+    }
+  }
 
-    return geoSearchService.getStationsWithinRange(queryParams, filterParams);
+  private boolean isRangeSearch(Double range, Double lat, Double lon) {
+    return range != null && lat != null && lon != null;
+  }
+
+  private boolean isBoundingBoxSearch(
+    Double minimumLatitude,
+    Double minimumLongitude,
+    Double maximumLatitude,
+    Double maximumLongitude
+  ) {
+    return (
+      minimumLatitude != null &&
+      minimumLongitude != null &&
+      maximumLatitude != null &&
+      maximumLongitude != null
+    );
   }
 
   public Station getStation(String id) {

--- a/src/main/java/org/entur/lamassu/controller/GraphQLQueryController.java
+++ b/src/main/java/org/entur/lamassu/controller/GraphQLQueryController.java
@@ -127,8 +127,7 @@ public class GraphQLQueryController implements GraphQLQueryResolver {
         boundingBoxQueryParameters,
         filterParams
       );
-    } else if (range != null && lat != null && lon != null) {
-      // add conditional to verify range search
+    } else if (isRangeSearch(range, lat, lon)) {
       validateRange(range);
 
       var rangeQueryParameters = new RangeQueryParameters();
@@ -196,7 +195,6 @@ public class GraphQLQueryController implements GraphQLQueryResolver {
         maximumLongitude
       )
     ) {
-      // TODO validate params, e.g.  [(170,60), (-170,70)]
       var boundingBoxQueryParameters = new BoundingBoxQueryParameters();
       boundingBoxQueryParameters.setMinimumLatitude(minimumLatitude);
       boundingBoxQueryParameters.setMinimumLongitude(minimumLongitude);

--- a/src/main/java/org/entur/lamassu/service/BoundingBoxQueryParameters.java
+++ b/src/main/java/org/entur/lamassu/service/BoundingBoxQueryParameters.java
@@ -1,0 +1,59 @@
+/*
+ *
+ *
+ *  * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ *  * the European Commission - subsequent versions of the EUPL (the "Licence");
+ *  * You may not use this work except in compliance with the Licence.
+ *  * You may obtain a copy of the Licence at:
+ *  *
+ *  *   https://joinup.ec.europa.eu/software/page/eupl
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the Licence is distributed on an "AS IS" basis,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the Licence for the specific language governing permissions and
+ *  * limitations under the Licence.
+ *
+ */
+
+package org.entur.lamassu.service;
+
+public class BoundingBoxQueryParameters {
+
+  private Double minimumLatitude;
+  private Double minimumLongitude;
+  private Double maximumLatitude;
+  private Double maximumLongitude;
+
+  public Double getMinimumLatitude() {
+    return minimumLatitude;
+  }
+
+  public void setMinimumLatitude(Double minimumLatitude) {
+    this.minimumLatitude = minimumLatitude;
+  }
+
+  public Double getMinimumLongitude() {
+    return minimumLongitude;
+  }
+
+  public void setMinimumLongitude(Double minimumLongitude) {
+    this.minimumLongitude = minimumLongitude;
+  }
+
+  public Double getMaximumLatitude() {
+    return maximumLatitude;
+  }
+
+  public void setMaximumLatitude(Double maximumLatitude) {
+    this.maximumLatitude = maximumLatitude;
+  }
+
+  public Double getMaximumLongitude() {
+    return maximumLongitude;
+  }
+
+  public void setMaximumLongitude(Double maximumLongitude) {
+    this.maximumLongitude = maximumLongitude;
+  }
+}

--- a/src/main/java/org/entur/lamassu/service/FilterParameters.java
+++ b/src/main/java/org/entur/lamassu/service/FilterParameters.java
@@ -25,6 +25,7 @@ public class FilterParameters {
   private List<String> codespaces;
   private List<String> systems;
   private List<String> operators;
+  private Integer count;
 
   public List<String> getCodespaces() {
     return codespaces;
@@ -48,5 +49,13 @@ public class FilterParameters {
 
   public void setOperators(List<String> operators) {
     this.operators = operators;
+  }
+
+  public Integer getCount() {
+    return count;
+  }
+
+  public void setCount(Integer count) {
+    this.count = count;
   }
 }

--- a/src/main/java/org/entur/lamassu/service/GeoSearchService.java
+++ b/src/main/java/org/entur/lamassu/service/GeoSearchService.java
@@ -10,8 +10,16 @@ public interface GeoSearchService {
     RangeQueryParameters rangeQueryParameters,
     VehicleFilterParameters vehicleFilterParameters
   );
+  List<Vehicle> getVehiclesInBoundingBox(
+    BoundingBoxQueryParameters boundingBoxQueryParameters,
+    VehicleFilterParameters vehicleFilterParameters
+  );
   List<Station> getStationsWithinRange(
     RangeQueryParameters rangeQueryParameters,
+    StationFilterParameters stationFilterParameters
+  );
+  List<Station> getStationsInBoundingBox(
+    BoundingBoxQueryParameters boundingBoxQueryParameters,
     StationFilterParameters stationFilterParameters
   );
   Collection<String> getVehicleSpatialIndexOrphans();

--- a/src/main/java/org/entur/lamassu/service/GeoSearchService.java
+++ b/src/main/java/org/entur/lamassu/service/GeoSearchService.java
@@ -6,11 +6,11 @@ import org.entur.lamassu.model.entities.Station;
 import org.entur.lamassu.model.entities.Vehicle;
 
 public interface GeoSearchService {
-  List<Vehicle> getVehiclesNearby(
+  List<Vehicle> getVehiclesWithinRange(
     RangeQueryParameters rangeQueryParameters,
     VehicleFilterParameters vehicleFilterParameters
   );
-  List<Station> getStationsNearby(
+  List<Station> getStationsWithinRange(
     RangeQueryParameters rangeQueryParameters,
     StationFilterParameters stationFilterParameters
   );

--- a/src/main/java/org/entur/lamassu/service/RangeQueryParameters.java
+++ b/src/main/java/org/entur/lamassu/service/RangeQueryParameters.java
@@ -29,5 +29,4 @@ public class RangeQueryParameters {
   public void setRange(Double range) {
     this.range = range;
   }
-
 }

--- a/src/main/java/org/entur/lamassu/service/RangeQueryParameters.java
+++ b/src/main/java/org/entur/lamassu/service/RangeQueryParameters.java
@@ -5,7 +5,6 @@ public class RangeQueryParameters {
   private Double lat;
   private Double lon;
   private Double range;
-  private Integer count;
 
   public Double getLat() {
     return lat;
@@ -31,11 +30,4 @@ public class RangeQueryParameters {
     this.range = range;
   }
 
-  public Integer getCount() {
-    return count;
-  }
-
-  public void setCount(Integer count) {
-    this.count = count;
-  }
 }

--- a/src/main/java/org/entur/lamassu/service/impl/GeoSearchServiceImpl.java
+++ b/src/main/java/org/entur/lamassu/service/impl/GeoSearchServiceImpl.java
@@ -45,7 +45,7 @@ public class GeoSearchServiceImpl implements GeoSearchService {
   }
 
   @Override
-  public List<Vehicle> getVehiclesNearby(
+  public List<Vehicle> getVehiclesWithinRange(
     RangeQueryParameters rangeQueryParameters,
     VehicleFilterParameters vehicleFilterParameters
   ) {
@@ -80,7 +80,7 @@ public class GeoSearchServiceImpl implements GeoSearchService {
   }
 
   @Override
-  public List<Station> getStationsNearby(
+  public List<Station> getStationsWithinRange(
     RangeQueryParameters rangeQueryParameters,
     StationFilterParameters filterParameters
   ) {

--- a/src/main/java/org/entur/lamassu/service/impl/GeoSearchServiceImpl.java
+++ b/src/main/java/org/entur/lamassu/service/impl/GeoSearchServiceImpl.java
@@ -52,7 +52,6 @@ public class GeoSearchServiceImpl implements GeoSearchService {
     Double longitude = rangeQueryParameters.getLon();
     Double latitude = rangeQueryParameters.getLat();
     Double range = rangeQueryParameters.getRange();
-    Integer count = rangeQueryParameters.getCount();
 
     List<VehicleSpatialIndexId> indexIds = vehicleSpatialIndex.radius(
       longitude,
@@ -66,6 +65,8 @@ public class GeoSearchServiceImpl implements GeoSearchService {
       .stream()
       .filter(Objects::nonNull)
       .filter(id -> SpatialIndexIdFilter.filterVehicle(id, vehicleFilterParameters));
+
+    Integer count = vehicleFilterParameters.getCount();
 
     if (count != null) {
       stream = stream.limit(count.longValue());
@@ -86,7 +87,6 @@ public class GeoSearchServiceImpl implements GeoSearchService {
     Double longitude = rangeQueryParameters.getLon();
     Double latitude = rangeQueryParameters.getLat();
     Double range = rangeQueryParameters.getRange();
-    Integer count = rangeQueryParameters.getCount();
 
     List<StationSpatialIndexId> indexIds = stationSpatialIndex.radius(
       longitude,
@@ -100,6 +100,8 @@ public class GeoSearchServiceImpl implements GeoSearchService {
       .stream()
       .filter(Objects::nonNull)
       .filter(id -> SpatialIndexIdFilter.filterStation(id, filterParameters));
+
+    Integer count = filterParameters.getCount();
 
     if (count != null) {
       stream = stream.limit(count.longValue());

--- a/src/main/java/org/entur/lamassu/service/impl/GeoUtils.java
+++ b/src/main/java/org/entur/lamassu/service/impl/GeoUtils.java
@@ -68,15 +68,15 @@ public class GeoUtils {
     rangeQueryParameters.setLon(envelope.getCenterX());
     rangeQueryParameters.setLat(envelope.getCenterY());
 
-    // The diameter of the circle that encloses the envelope is equal to the diameter
-    // of the envelope itself, hence half the diameter equals the circle's radius
+    // The diameter of the circle that encloses the envelope is equal to the length
+    // of the diagonal of the envelope, hence half this length equals the circle's radius
     rangeQueryParameters.setRange(getDiagonalLength(envelope) / 2.0);
     return rangeQueryParameters;
   }
 
   /**
    * Find the great circle distance between the southwest and northeast corners of the envelope,
-   * which we called the diameter of the envelope.
+   * which we called the diagonal length of the envelope.
    * @param envelope
    * @return
    */

--- a/src/main/java/org/entur/lamassu/service/impl/GeoUtils.java
+++ b/src/main/java/org/entur/lamassu/service/impl/GeoUtils.java
@@ -70,7 +70,7 @@ public class GeoUtils {
 
     // The diameter of the circle that encloses the envelope is equal to the diameter
     // of the envelope itself, hence half the diameter equals the circle's radius
-    rangeQueryParameters.setRange(getDiameter(envelope) / 2.0);
+    rangeQueryParameters.setRange(getDiagonalLength(envelope) / 2.0);
     return rangeQueryParameters;
   }
 
@@ -80,7 +80,7 @@ public class GeoUtils {
    * @param envelope
    * @return
    */
-  private static double getDiameter(ReferencedEnvelope envelope) {
+  private static double getDiagonalLength(ReferencedEnvelope envelope) {
     double distance = 0.0;
     try {
       GeodeticCalculator gc = GeodeticCalculatorPoolManager.get();

--- a/src/main/java/org/entur/lamassu/service/impl/GeoUtils.java
+++ b/src/main/java/org/entur/lamassu/service/impl/GeoUtils.java
@@ -82,16 +82,18 @@ public class GeoUtils {
    * @return
    */
   private static double getDiagonalLength(ReferencedEnvelope envelope) {
-    GeodeticCalculator gc = null;
+    GeodeticCalculator geodeticCalculator = null;
     try {
-      gc = GeodeticCalculatorPoolManager.getInstance().get();
+      geodeticCalculator = GeodeticCalculatorPoolManager.getInstance().get();
       Coordinate start = new CoordinateXY(envelope.getMinX(), envelope.getMinY());
       Coordinate end = new CoordinateXY(envelope.getMaxX(), envelope.getMaxY());
-      gc.setStartingPosition(JTS.toDirectPosition(start, DefaultGeographicCRS.WGS84));
-      gc.setDestinationPosition(JTS.toDirectPosition(end, DefaultGeographicCRS.WGS84));
-      return gc.getOrthodromicDistance();
-    } catch (TransformException e) {
-      throw new IllegalArgumentException(e);
+      geodeticCalculator.setStartingPosition(
+        JTS.toDirectPosition(start, DefaultGeographicCRS.WGS84)
+      );
+      geodeticCalculator.setDestinationPosition(
+        JTS.toDirectPosition(end, DefaultGeographicCRS.WGS84)
+      );
+      return geodeticCalculator.getOrthodromicDistance();
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       throw new IllegalStateException(
@@ -99,9 +101,12 @@ public class GeoUtils {
         e
       );
     } catch (Exception e) {
-      throw new RuntimeException(e);
+      throw new IllegalStateException(
+        "Unable to calculate diagonal length of envelope",
+        e
+      );
     } finally {
-      GeodeticCalculatorPoolManager.getInstance().release(gc);
+      GeodeticCalculatorPoolManager.getInstance().release(geodeticCalculator);
     }
   }
 

--- a/src/main/java/org/entur/lamassu/service/impl/GeoUtils.java
+++ b/src/main/java/org/entur/lamassu/service/impl/GeoUtils.java
@@ -58,8 +58,14 @@ public class GeoUtils {
     ReferencedEnvelope envelope
   ) {
     RangeQueryParameters rangeQueryParameters = new RangeQueryParameters();
+
+    // The center of the circle that encloses the envelope is equal to the center
+    // of the envelope itself
     rangeQueryParameters.setLon(envelope.getCenterX());
     rangeQueryParameters.setLat(envelope.getCenterY());
+
+    // The diameter of the circle that encloses the envelope is equal to the diameter
+    // of the envelope itself, hence half the diameter equals the circle's radius
     rangeQueryParameters.setRange(getDiameter(envelope) / 2.0);
     return rangeQueryParameters;
   }

--- a/src/main/java/org/entur/lamassu/service/impl/GeoUtils.java
+++ b/src/main/java/org/entur/lamassu/service/impl/GeoUtils.java
@@ -23,7 +23,6 @@ import org.apache.commons.pool.PoolableObjectFactory;
 import org.apache.commons.pool.impl.GenericObjectPool;
 import org.entur.lamassu.service.BoundingBoxQueryParameters;
 import org.entur.lamassu.service.RangeQueryParameters;
-import org.geotools.api.referencing.operation.TransformException;
 import org.geotools.geometry.jts.JTS;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.GeodeticCalculator;

--- a/src/main/java/org/entur/lamassu/service/impl/GeoUtils.java
+++ b/src/main/java/org/entur/lamassu/service/impl/GeoUtils.java
@@ -78,8 +78,7 @@ public class GeoUtils {
    */
   private static double getDiameter(ReferencedEnvelope envelope) {
     try {
-      // TODO GeodeticCalculator not thread-safe, should be pooled
-      GeodeticCalculator gc = new GeodeticCalculator(DefaultGeographicCRS.WGS84);
+      GeodeticCalculator gc = GeodeticCalculatorSingleton.getInstance();
       Coordinate start = new CoordinateXY(envelope.getMinX(), envelope.getMinY());
       Coordinate end = new CoordinateXY(envelope.getMaxX(), envelope.getMaxY());
       gc.setStartingPosition(JTS.toDirectPosition(start, DefaultGeographicCRS.WGS84));
@@ -87,6 +86,19 @@ public class GeoUtils {
       return gc.getOrthodromicDistance();
     } catch (TransformException e) {
       throw new IllegalArgumentException(e);
+    }
+  }
+
+  // GeodeticCalculator not thread-safe, so we make thread-local singletons
+  private static class GeodeticCalculatorSingleton {
+
+    private GeodeticCalculatorSingleton() {}
+
+    private static final ThreadLocal<GeodeticCalculator> _threadLocal =
+      ThreadLocal.withInitial(() -> new GeodeticCalculator(DefaultGeographicCRS.WGS84));
+
+    public static GeodeticCalculator getInstance() {
+      return _threadLocal.get();
     }
   }
 }

--- a/src/main/java/org/entur/lamassu/service/impl/GeoUtils.java
+++ b/src/main/java/org/entur/lamassu/service/impl/GeoUtils.java
@@ -1,0 +1,86 @@
+/*
+ *
+ *
+ *  * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ *  * the European Commission - subsequent versions of the EUPL (the "Licence");
+ *  * You may not use this work except in compliance with the Licence.
+ *  * You may obtain a copy of the Licence at:
+ *  *
+ *  *   https://joinup.ec.europa.eu/software/page/eupl
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the Licence is distributed on an "AS IS" basis,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the Licence for the specific language governing permissions and
+ *  * limitations under the Licence.
+ *
+ */
+
+package org.entur.lamassu.service.impl;
+
+import org.entur.lamassu.service.BoundingBoxQueryParameters;
+import org.entur.lamassu.service.RangeQueryParameters;
+import org.geotools.api.referencing.operation.TransformException;
+import org.geotools.geometry.jts.JTS;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.referencing.GeodeticCalculator;
+import org.geotools.referencing.crs.DefaultGeographicCRS;
+import org.jetbrains.annotations.NotNull;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.CoordinateXY;
+
+public class GeoUtils {
+
+  /**
+   * Map the bounding box parameters to a geometric envelope
+   * @param boundingBoxQueryParameters
+   * @return
+   */
+  public static @NotNull ReferencedEnvelope mapToEnvelope(
+    BoundingBoxQueryParameters boundingBoxQueryParameters
+  ) {
+    return new ReferencedEnvelope(
+      boundingBoxQueryParameters.getMinimumLongitude(),
+      boundingBoxQueryParameters.getMaximumLongitude(),
+      boundingBoxQueryParameters.getMinimumLatitude(),
+      boundingBoxQueryParameters.getMaximumLatitude(),
+      DefaultGeographicCRS.WGS84
+    );
+  }
+
+  /**
+   * Uses the center of the envelope, and the radius of the circle the encloses the envelope to
+   * define the coordinates and range of the range query parameters.
+   * @param envelope
+   * @return
+   */
+  public static @NotNull RangeQueryParameters mapToRangeQueryParameters(
+    ReferencedEnvelope envelope
+  ) {
+    RangeQueryParameters rangeQueryParameters = new RangeQueryParameters();
+    rangeQueryParameters.setLon(envelope.getCenterX());
+    rangeQueryParameters.setLat(envelope.getCenterY());
+    rangeQueryParameters.setRange(getDiameter(envelope) / 2.0);
+    return rangeQueryParameters;
+  }
+
+  /**
+   * Find the great circle distance between the southwest and northeast corners of the envelope,
+   * which we called the diameter of the envelope.
+   * @param envelope
+   * @return
+   */
+  private static double getDiameter(ReferencedEnvelope envelope) {
+    try {
+      // TODO GeodeticCalculator not thread-safe, should be pooled
+      GeodeticCalculator gc = new GeodeticCalculator(DefaultGeographicCRS.WGS84);
+      Coordinate start = new CoordinateXY(envelope.getMinX(), envelope.getMinY());
+      Coordinate end = new CoordinateXY(envelope.getMaxX(), envelope.getMaxY());
+      gc.setStartingPosition(JTS.toDirectPosition(start, DefaultGeographicCRS.WGS84));
+      gc.setDestinationPosition(JTS.toDirectPosition(end, DefaultGeographicCRS.WGS84));
+      return gc.getOrthodromicDistance();
+    } catch (TransformException e) {
+      throw new IllegalArgumentException(e);
+    }
+  }
+}

--- a/src/main/java/org/entur/lamassu/service/impl/GeoUtils.java
+++ b/src/main/java/org/entur/lamassu/service/impl/GeoUtils.java
@@ -30,6 +30,7 @@ import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.CoordinateXY;
 
 public class GeoUtils {
+  private GeoUtils() {}
 
   /**
    * Map the bounding box parameters to a geometric envelope

--- a/src/main/java/org/entur/lamassu/service/impl/GeoUtils.java
+++ b/src/main/java/org/entur/lamassu/service/impl/GeoUtils.java
@@ -93,7 +93,10 @@ public class GeoUtils {
       throw new IllegalArgumentException(e);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
-      throw new IllegalStateException("Unable to calculate diagonal length of envelope", e);
+      throw new IllegalStateException(
+        "Unable to calculate diagonal length of envelope",
+        e
+      );
     } finally {
       GeodeticCalculatorPoolManager.release(gc);
     }

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -18,6 +18,18 @@ type Query {
         "Search radius in meters. Required unless using 'ids'"
         range: Int
 
+        "Bounding box minimum latitude"
+        minimumLatitude: Float
+
+        "Bounding box minimum longitude"
+        minimumLongitude: Float
+
+        "Bounding box maximum latitude"
+        maximumLatitude: Float
+
+        "Bounding box maximum longitude"
+        maximumLongitude: Float
+
         "Max results to return."
         count: Int
 
@@ -57,6 +69,18 @@ type Query {
 
         "Search radius in meters. Required unless using 'ids'"
         range: Int
+
+        "Bounding box minimum latitude"
+        minimumLatitude: Float
+
+        "Bounding box minimum longitude"
+        minimumLongitude: Float
+
+        "Bounding box maximum latitude"
+        maximumLatitude: Float
+
+        "Bounding box maximum longitude"
+        maximumLongitude: Float
 
         "Max results to return."
         count: Int

--- a/src/test/java/org/entur/lamassu/integration/GraphQLIntegrationTest.java
+++ b/src/test/java/org/entur/lamassu/integration/GraphQLIntegrationTest.java
@@ -194,4 +194,19 @@ public class GraphQLIntegrationTest extends AbstractIntegrationTestBase {
         .size()
     );
   }
+
+  @Test
+  public void testStationsBoundingBoxQuery() throws IOException {
+    GraphQLResponse response = graphQLTestTemplate.postForResource(
+      "stations_bbox_query.graphql"
+    );
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertEquals(
+      1,
+      JsonPath
+        .parse(response.getRawResponse().getBody())
+        .read("$.data.stations", List.class)
+        .size()
+    );
+  }
 }

--- a/src/test/java/org/entur/lamassu/integration/GraphQLIntegrationTest.java
+++ b/src/test/java/org/entur/lamassu/integration/GraphQLIntegrationTest.java
@@ -178,4 +178,20 @@ public class GraphQLIntegrationTest extends AbstractIntegrationTestBase {
         .isEmpty()
     );
   }
+
+  @Test
+  public void testVehiclesBoundingBoxQuery() throws IOException {
+    GraphQLResponse response = graphQLTestTemplate.postForResource(
+      "vehicles_bbox_query.graphql"
+    );
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+
+    assertEquals(
+      2,
+      JsonPath
+        .parse(response.getRawResponse().getBody())
+        .read("$.data.vehicles", List.class)
+        .size()
+    );
+  }
 }

--- a/src/test/resources/stations_bbox_query.graphql
+++ b/src/test/resources/stations_bbox_query.graphql
@@ -1,0 +1,14 @@
+{
+    stations(
+        minimumLongitude: 44.0,
+        minimumLatitude: 11.0,
+        maximumLongitude: 45.0
+        maximumLatitude: 12.0
+        count: 1
+    ) {
+        id
+        lat
+        lon
+    }
+}
+,

--- a/src/test/resources/vehicles_bbox_query.graphql
+++ b/src/test/resources/vehicles_bbox_query.graphql
@@ -1,0 +1,14 @@
+{
+    vehicles(
+        minimumLongitude: 10.0,
+        minimumLatitude: 59.0,
+        maximumLongitude: 11.0
+        maximumLatitude: 60.0
+        count: 2,
+        includeDisabled: true
+    ) {
+        id
+        lat
+        lon
+    }
+}


### PR DESCRIPTION
### Summary

This PR adds bounding box search functionality to vehicles and stations queries.

It should be noted that this method is *not* quicker than using radius, because the implementation must first do the radius search and do post-filtering. There is also some overhead in calculating the circle.

Closes #525 

### Unit tests

Added integrationt tests

### Documentation

Documentation added to graphql schema. geometric functionality documented in code