### PR TITLE
Update subscription immediately after registration

### DIFF
--- a/src/main/java/org/entur/lamassu/leader/FeedUpdater.java
+++ b/src/main/java/org/entur/lamassu/leader/FeedUpdater.java
@@ -185,6 +185,8 @@ public class FeedUpdater {
     } else {
       logger.info("Setup subscription complete systemId={}", feedProvider.getSystemId());
       metricsService.registerSubscriptionSetup(feedProvider, true);
+      // after registration, immediately update the feed
+      subscriptionManager.update(id);
     }
   }
 


### PR DESCRIPTION
### Summary

With this PR, a feed update (i.e. caching the feeds) is performed immediately after successful subscription. 
That way, feeds will be available not only after `org.entur.lamassu.feedupdateinterval`, which e.g. for test instances, could be very high. 

### Issue
Closes #581. 

### Unit tests

Write a few words on how the new code is tested.

No tests were added/updated. All existing, enabled tests passed.

### Documentation