### PR TITLE
Add null checks to avoid NPE

### DIFF
--- a/src/main/java/org/entur/lamassu/graphql/resolver/vehicletype/VehicleTypePricingPlanResolver.java
+++ b/src/main/java/org/entur/lamassu/graphql/resolver/vehicletype/VehicleTypePricingPlanResolver.java
@@ -19,11 +19,17 @@ public class VehicleTypePricingPlanResolver {
 
   @SchemaMapping(typeName = "VehicleType", field = "defaultPricingPlan")
   public PricingPlan defaultPricingPlan(VehicleType vehicleType) {
+    if (vehicleType.getDefaultPricingPlanId() == null) {
+      return null;
+    }
     return pricingPlanCache.get(vehicleType.getDefaultPricingPlanId());
   }
 
   @SchemaMapping(typeName = "VehicleType", field = "pricingPlans")
   public List<PricingPlan> pricingPlans(VehicleType vehicleType) {
+    if (vehicleType.getPricingPlanIds() == null) {
+      return null;
+    }
     return pricingPlanCache.getAll(
       vehicleType.getPricingPlanIds().stream().collect(Collectors.toSet())
     );


### PR DESCRIPTION
#596 introduced an NPE possibility if trying to resolve pricing plans but the ids were null. This fields are actually optional in the graphql schema, so it's not a breaking change.