### PR TITLE
Add request-scope cache for reading entities

### DIFF
--- a/src/main/java/org/entur/lamassu/cache/EntityCache.java
+++ b/src/main/java/org/entur/lamassu/cache/EntityCache.java
@@ -1,19 +1,22 @@
 package org.entur.lamassu.cache;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.entur.lamassu.model.entities.Entity;
 
-public interface EntityCache<T extends Entity> {
-  List<T> getAll(Set<String> keys);
-  List<T> getAll();
-  Map<String, T> getAllAsMap(Set<String> keys);
-  T get(String key);
+/**
+ * Interface for read-write operations on entity caches.
+ * Extends EntityReader to inherit all read operations while adding write capabilities.
+ */
+public interface EntityCache<T extends Entity> extends EntityReader<T> {
+  /**
+   * Update multiple entities in the cache with a TTL
+   */
   void updateAll(Map<String, T> entities, int ttl, TimeUnit timeUnit);
-  void removeAll(Set<String> keys);
-  boolean hasKey(String key);
 
-  int count();
+  /**
+   * Remove multiple entities from the cache
+   */
+  void removeAll(Set<String> keys);
 }

--- a/src/main/java/org/entur/lamassu/cache/EntityReader.java
+++ b/src/main/java/org/entur/lamassu/cache/EntityReader.java
@@ -1,0 +1,43 @@
+package org.entur.lamassu.cache;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.entur.lamassu.model.entities.Entity;
+
+/**
+ * Interface for read-only operations on entity caches.
+ * This separation allows for safer handling of caches where write operations
+ * should be restricted to specific components.
+ */
+public interface EntityReader<T extends Entity> {
+  /**
+   * Get all entities for the given keys
+   */
+  List<T> getAll(Set<String> keys);
+
+  /**
+   * Get all entities in the cache
+   */
+  List<T> getAll();
+
+  /**
+   * Get all entities for the given keys as a map
+   */
+  Map<String, T> getAllAsMap(Set<String> keys);
+
+  /**
+   * Get a single entity by key
+   */
+  T get(String key);
+
+  /**
+   * Check if a key exists in the cache
+   */
+  boolean hasKey(String key);
+
+  /**
+   * Get the total number of entities in the cache
+   */
+  int count();
+}

--- a/src/main/java/org/entur/lamassu/cache/RequestScopedCache.java
+++ b/src/main/java/org/entur/lamassu/cache/RequestScopedCache.java
@@ -1,0 +1,30 @@
+package org.entur.lamassu.cache;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.stereotype.Component;
+
+@Component
+@Scope(value = "request", proxyMode = ScopedProxyMode.TARGET_CLASS)
+public class RequestScopedCache {
+
+  private final Map<String, Object> cache = new ConcurrentHashMap<>();
+
+  public <T> T get(String key, Class<T> type) {
+    return type.cast(cache.get(key));
+  }
+
+  public void put(String key, Object value) {
+    cache.put(key, value);
+  }
+
+  public boolean contains(String key) {
+    return cache.containsKey(key);
+  }
+
+  public void clear() {
+    cache.clear();
+  }
+}

--- a/src/main/java/org/entur/lamassu/cache/RequestScopedEntityReader.java
+++ b/src/main/java/org/entur/lamassu/cache/RequestScopedEntityReader.java
@@ -1,0 +1,137 @@
+package org.entur.lamassu.cache;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.entur.lamassu.model.entities.Entity;
+import org.springframework.web.context.request.RequestContextHolder;
+
+/**
+ * A read-only decorator for EntityReader that adds request-level caching.
+ * This implementation only provides read operations and caches results within
+ * the scope of an HTTP request.
+ */
+public class RequestScopedEntityReader<T extends Entity> implements EntityReader<T> {
+
+  private final EntityReader<T> delegate;
+  private final RequestScopedCache requestCache;
+  private final String cachePrefix;
+
+  public RequestScopedEntityReader(
+    EntityReader<T> delegate,
+    RequestScopedCache requestCache,
+    String cachePrefix
+  ) {
+    this.delegate = delegate;
+    this.requestCache = requestCache;
+    this.cachePrefix = cachePrefix;
+  }
+
+  private String getCacheKey(String key) {
+    return cachePrefix + ":" + key;
+  }
+
+  private boolean isRequestContextActive() {
+    try {
+      return RequestContextHolder.getRequestAttributes() != null;
+    } catch (IllegalStateException e) {
+      return false;
+    }
+  }
+
+  private T getFromRequestCache(String key) {
+    if (!isRequestContextActive()) {
+      return null;
+    }
+    try {
+      String cacheKey = getCacheKey(key);
+      return requestCache.get(cacheKey, (Class<T>) Entity.class);
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
+  private void putInRequestCache(String key, T value) {
+    if (!isRequestContextActive()) {
+      return;
+    }
+    try {
+      requestCache.put(getCacheKey(key), value);
+    } catch (Exception e) {
+      // Ignore cache errors in non-request contexts
+    }
+  }
+
+  @Override
+  public List<T> getAll(Set<String> keys) {
+    Map<String, T> result = getAllAsMap(keys);
+    return new ArrayList<>(result.values());
+  }
+
+  @Override
+  public List<T> getAll() {
+    return delegate.getAll();
+  }
+
+  @Override
+  public Map<String, T> getAllAsMap(Set<String> keys) {
+    if (!isRequestContextActive()) {
+      return delegate.getAllAsMap(keys);
+    }
+
+    Map<String, T> result = new HashMap<>();
+    Set<String> missingKeys = new HashSet<>();
+
+    // Check request cache first
+    for (String key : keys) {
+      T value = getFromRequestCache(key);
+      if (value != null) {
+        result.put(key, value);
+      } else {
+        missingKeys.add(key);
+      }
+    }
+
+    // Get missing keys from delegate
+    if (!missingKeys.isEmpty()) {
+      Map<String, T> delegateResults = delegate.getAllAsMap(missingKeys);
+      delegateResults.forEach((key, value) -> {
+        result.put(key, value);
+        putInRequestCache(key, value);
+      });
+    }
+
+    return result;
+  }
+
+  @Override
+  public T get(String key) {
+    T value = getFromRequestCache(key);
+    if (value == null) {
+      value = delegate.get(key);
+      if (value != null) {
+        putInRequestCache(key, value);
+      }
+    }
+    return value;
+  }
+
+  @Override
+  public boolean hasKey(String key) {
+    if (isRequestContextActive()) {
+      T value = getFromRequestCache(key);
+      if (value != null) {
+        return true;
+      }
+    }
+    return delegate.hasKey(key);
+  }
+
+  @Override
+  public int count() {
+    return delegate.count();
+  }
+}

--- a/src/main/java/org/entur/lamassu/config/cache/RequestScopedCacheConfig.java
+++ b/src/main/java/org/entur/lamassu/config/cache/RequestScopedCacheConfig.java
@@ -1,0 +1,49 @@
+package org.entur.lamassu.config.cache;
+
+import org.entur.lamassu.cache.*;
+import org.entur.lamassu.model.entities.*;
+import org.entur.lamassu.model.entities.System;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+public class RequestScopedCacheConfig {
+
+  @Bean
+  @Primary
+  public EntityReader<System> requestScopedSystemReader(
+    @Qualifier("systemCacheImpl") EntityCache<System> systemCache,
+    RequestScopedCache requestCache
+  ) {
+    return new RequestScopedEntityReader<>(systemCache, requestCache, "system");
+  }
+
+  @Bean
+  @Primary
+  public EntityReader<VehicleType> requestScopedVehicleTypeReader(
+    @Qualifier("vehicleTypeCacheImpl") EntityCache<VehicleType> vehicleTypeCache,
+    RequestScopedCache requestCache
+  ) {
+    return new RequestScopedEntityReader<>(vehicleTypeCache, requestCache, "vehicleType");
+  }
+
+  @Bean
+  @Primary
+  public EntityReader<PricingPlan> requestScopedPricingPlanReader(
+    @Qualifier("pricingPlanCacheImpl") EntityCache<PricingPlan> pricingPlanCache,
+    RequestScopedCache requestCache
+  ) {
+    return new RequestScopedEntityReader<>(pricingPlanCache, requestCache, "pricingPlan");
+  }
+
+  @Bean
+  @Primary
+  public EntityReader<Region> requestScopedRegionReader(
+    @Qualifier("regionCacheImpl") EntityCache<Region> regionCache,
+    RequestScopedCache requestCache
+  ) {
+    return new RequestScopedEntityReader<>(regionCache, requestCache, "region");
+  }
+}

--- a/src/main/java/org/entur/lamassu/graphql/query/GeofencingZonesQueryController.java
+++ b/src/main/java/org/entur/lamassu/graphql/query/GeofencingZonesQueryController.java
@@ -2,7 +2,7 @@ package org.entur.lamassu.graphql.query;
 
 import java.util.List;
 import java.util.Set;
-import org.entur.lamassu.cache.EntityCache;
+import org.entur.lamassu.cache.EntityReader;
 import org.entur.lamassu.graphql.validation.QueryParameterValidator;
 import org.entur.lamassu.model.entities.GeofencingZones;
 import org.springframework.graphql.data.method.annotation.Argument;
@@ -12,14 +12,14 @@ import org.springframework.stereotype.Controller;
 @Controller
 public class GeofencingZonesQueryController {
 
-  private final EntityCache<GeofencingZones> geofencingZonesCache;
+  private final EntityReader<GeofencingZones> geofencingZonesReader;
   private final QueryParameterValidator validationService;
 
   public GeofencingZonesQueryController(
-    EntityCache<GeofencingZones> geofencingZonesCache,
+    EntityReader<GeofencingZones> geofencingZonesReader,
     QueryParameterValidator validationService
   ) {
-    this.geofencingZonesCache = geofencingZonesCache;
+    this.geofencingZonesReader = geofencingZonesReader;
     this.validationService = validationService;
   }
 
@@ -27,8 +27,8 @@ public class GeofencingZonesQueryController {
   public List<GeofencingZones> geofencingZones(@Argument List<String> systemIds) {
     validationService.validateSystems(systemIds);
     if (systemIds != null && !systemIds.isEmpty()) {
-      return geofencingZonesCache.getAll(Set.copyOf(systemIds));
+      return geofencingZonesReader.getAll(Set.copyOf(systemIds));
     }
-    return geofencingZonesCache.getAll();
+    return geofencingZonesReader.getAll();
   }
 }

--- a/src/main/java/org/entur/lamassu/graphql/query/StationQueryController.java
+++ b/src/main/java/org/entur/lamassu/graphql/query/StationQueryController.java
@@ -3,7 +3,7 @@ package org.entur.lamassu.graphql.query;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
-import org.entur.lamassu.cache.EntityCache;
+import org.entur.lamassu.cache.EntityReader;
 import org.entur.lamassu.graphql.validation.QueryParameterValidator;
 import org.entur.lamassu.model.entities.FormFactor;
 import org.entur.lamassu.model.entities.PropulsionType;
@@ -20,22 +20,22 @@ import org.springframework.stereotype.Controller;
 public class StationQueryController {
 
   private final GeoSearchService geoSearchService;
-  private final EntityCache<Station> stationCache;
+  private final EntityReader<Station> stationReader;
   private final QueryParameterValidator validationService;
 
   public StationQueryController(
     GeoSearchService geoSearchService,
-    EntityCache<Station> stationCache,
+    EntityReader<Station> stationReader,
     QueryParameterValidator validationService
   ) {
     this.geoSearchService = geoSearchService;
-    this.stationCache = stationCache;
+    this.stationReader = stationReader;
     this.validationService = validationService;
   }
 
   @QueryMapping
   public Station station(@Argument String id) {
-    return stationCache.get(id);
+    return stationReader.get(id);
   }
 
   @QueryMapping
@@ -56,7 +56,7 @@ public class StationQueryController {
     @Argument List<PropulsionType> availablePropulsionTypes
   ) {
     if (ids != null && !ids.isEmpty()) {
-      return stationCache.getAll(Set.copyOf(ids));
+      return stationReader.getAll(Set.copyOf(ids));
     }
 
     validationService.validateCount(count);
@@ -106,6 +106,6 @@ public class StationQueryController {
 
   @QueryMapping
   public Collection<Station> stationsById(@Argument List<String> ids) {
-    return stationCache.getAll(Set.copyOf(ids));
+    return stationReader.getAll(Set.copyOf(ids));
   }
 }

--- a/src/main/java/org/entur/lamassu/graphql/query/VehicleQueryController.java
+++ b/src/main/java/org/entur/lamassu/graphql/query/VehicleQueryController.java
@@ -1,9 +1,9 @@
 package org.entur.lamassu.graphql.query;
 
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
-import org.entur.lamassu.cache.EntityCache;
+import org.entur.lamassu.cache.EntityReader;
 import org.entur.lamassu.graphql.validation.QueryParameterValidator;
 import org.entur.lamassu.model.entities.FormFactor;
 import org.entur.lamassu.model.entities.PropulsionType;
@@ -20,22 +20,22 @@ import org.springframework.stereotype.Controller;
 public class VehicleQueryController {
 
   private final GeoSearchService geoSearchService;
-  private final EntityCache<Vehicle> vehicleCache;
+  private final EntityReader<Vehicle> vehicleReader;
   private final QueryParameterValidator validationService;
 
   public VehicleQueryController(
     GeoSearchService geoSearchService,
-    EntityCache<Vehicle> vehicleCache,
+    EntityReader<Vehicle> vehicleReader,
     QueryParameterValidator validationService
   ) {
     this.geoSearchService = geoSearchService;
-    this.vehicleCache = vehicleCache;
+    this.vehicleReader = vehicleReader;
     this.validationService = validationService;
   }
 
   @QueryMapping
   public Vehicle vehicle(@Argument String id) {
-    return vehicleCache.get(id);
+    return vehicleReader.get(id);
   }
 
   @QueryMapping
@@ -58,7 +58,7 @@ public class VehicleQueryController {
     @Argument Boolean includeDisabled
   ) {
     if (ids != null && !ids.isEmpty()) {
-      return vehicleCache.getAll(Set.copyOf(ids));
+      return vehicleReader.getAll(new HashSet<>(ids));
     }
 
     validationService.validateCount(count);

--- a/src/main/java/org/entur/lamassu/graphql/resolver/station/StationPricingPlanResolver.java
+++ b/src/main/java/org/entur/lamassu/graphql/resolver/station/StationPricingPlanResolver.java
@@ -7,7 +7,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.entur.lamassu.cache.EntityCache;
+import org.entur.lamassu.cache.EntityReader;
 import org.entur.lamassu.model.entities.PricingPlan;
 import org.entur.lamassu.model.entities.Station;
 import org.entur.lamassu.model.entities.VehicleDocksAvailability;
@@ -22,15 +22,15 @@ import org.springframework.stereotype.Controller;
 @Controller
 public class StationPricingPlanResolver {
 
-  private final EntityCache<VehicleType> vehicleTypeCache;
-  private final EntityCache<PricingPlan> pricingPlanCache;
+  private final EntityReader<VehicleType> vehicleTypeReader;
+  private final EntityReader<PricingPlan> pricingPlanReader;
 
   public StationPricingPlanResolver(
-    EntityCache<VehicleType> vehicleTypeCache,
-    EntityCache<PricingPlan> pricingPlanCache
+    EntityReader<VehicleType> vehicleTypeReader,
+    EntityReader<PricingPlan> pricingPlanReader
   ) {
-    this.vehicleTypeCache = vehicleTypeCache;
-    this.pricingPlanCache = pricingPlanCache;
+    this.vehicleTypeReader = vehicleTypeReader;
+    this.pricingPlanReader = pricingPlanReader;
   }
 
   /**
@@ -80,7 +80,7 @@ public class StationPricingPlanResolver {
       .flatMap(i -> i)
       .collect(Collectors.toSet());
 
-    List<VehicleType> vehicleTypes = vehicleTypeCache.getAll(vehicleTypeIds);
+    List<VehicleType> vehicleTypes = vehicleTypeReader.getAll(vehicleTypeIds);
 
     Set<String> pricingPlanIds = new HashSet<>();
 
@@ -93,6 +93,6 @@ public class StationPricingPlanResolver {
       }
     });
 
-    return pricingPlanCache.getAll(pricingPlanIds);
+    return pricingPlanReader.getAll(pricingPlanIds);
   }
 }

--- a/src/main/java/org/entur/lamassu/graphql/resolver/station/StationRegionResolver.java
+++ b/src/main/java/org/entur/lamassu/graphql/resolver/station/StationRegionResolver.java
@@ -1,6 +1,6 @@
 package org.entur.lamassu.graphql.resolver.station;
 
-import org.entur.lamassu.cache.EntityCache;
+import org.entur.lamassu.cache.EntityReader;
 import org.entur.lamassu.model.entities.Region;
 import org.entur.lamassu.model.entities.Station;
 import org.springframework.graphql.data.method.annotation.SchemaMapping;
@@ -9,10 +9,10 @@ import org.springframework.stereotype.Controller;
 @Controller
 public class StationRegionResolver {
 
-  private final EntityCache<Region> regionCache;
+  private final EntityReader<Region> regionReader;
 
-  public StationRegionResolver(EntityCache<Region> regionCache) {
-    this.regionCache = regionCache;
+  public StationRegionResolver(EntityReader<Region> regionReader) {
+    this.regionReader = regionReader;
   }
 
   @SchemaMapping(typeName = "Station", field = "region")
@@ -20,6 +20,6 @@ public class StationRegionResolver {
     if (station.getRegionId() == null) {
       return null;
     }
-    return regionCache.get(station.getRegionId());
+    return regionReader.get(station.getRegionId());
   }
 }

--- a/src/main/java/org/entur/lamassu/graphql/resolver/station/StationSystemResolver.java
+++ b/src/main/java/org/entur/lamassu/graphql/resolver/station/StationSystemResolver.java
@@ -1,6 +1,6 @@
 package org.entur.lamassu.graphql.resolver.station;
 
-import org.entur.lamassu.cache.EntityCache;
+import org.entur.lamassu.cache.EntityReader;
 import org.entur.lamassu.model.entities.Station;
 import org.entur.lamassu.model.entities.System;
 import org.springframework.graphql.data.method.annotation.SchemaMapping;
@@ -9,14 +9,14 @@ import org.springframework.stereotype.Controller;
 @Controller
 public class StationSystemResolver {
 
-  private final EntityCache<System> systemCache;
+  private final EntityReader<System> systemReader;
 
-  public StationSystemResolver(EntityCache<System> systemCache) {
-    this.systemCache = systemCache;
+  public StationSystemResolver(EntityReader<System> systemReader) {
+    this.systemReader = systemReader;
   }
 
   @SchemaMapping(typeName = "Station", field = "system")
   public System resolve(Station station) {
-    return systemCache.get(station.getSystemId());
+    return systemReader.get(station.getSystemId());
   }
 }

--- a/src/main/java/org/entur/lamassu/graphql/resolver/station/StationVehicleTypeResolver.java
+++ b/src/main/java/org/entur/lamassu/graphql/resolver/station/StationVehicleTypeResolver.java
@@ -2,7 +2,7 @@ package org.entur.lamassu.graphql.resolver.station;
 
 import java.util.HashSet;
 import java.util.List;
-import org.entur.lamassu.cache.EntityCache;
+import org.entur.lamassu.cache.EntityReader;
 import org.entur.lamassu.model.entities.VehicleDocksAvailability;
 import org.entur.lamassu.model.entities.VehicleDocksCapacity;
 import org.entur.lamassu.model.entities.VehicleType;
@@ -15,38 +15,38 @@ import org.springframework.stereotype.Controller;
 @Controller
 public class StationVehicleTypeResolver {
 
-  private final EntityCache<VehicleType> vehicleTypeCache;
+  private final EntityReader<VehicleType> vehicleTypeReader;
 
-  public StationVehicleTypeResolver(EntityCache<VehicleType> vehicleTypeCache) {
-    this.vehicleTypeCache = vehicleTypeCache;
+  public StationVehicleTypeResolver(EntityReader<VehicleType> vehicleTypeReader) {
+    this.vehicleTypeReader = vehicleTypeReader;
   }
 
   @SchemaMapping(typeName = "VehicleTypeAvailability", field = "vehicleType")
   public VehicleType resolveVehicleTypeAvailability(
     VehicleTypeAvailability vehicleTypeAvailability
   ) {
-    return vehicleTypeCache.get(vehicleTypeAvailability.getVehicleTypeId());
+    return vehicleTypeReader.get(vehicleTypeAvailability.getVehicleTypeId());
   }
 
   @SchemaMapping(typeName = "VehicleDocksAvailability", field = "vehicleTypes")
   public List<VehicleType> resolveVehicleDocksAvailability(
     VehicleDocksAvailability vehicleDocksAvailability
   ) {
-    return vehicleTypeCache.getAll(
+    return vehicleTypeReader.getAll(
       new HashSet<>(vehicleDocksAvailability.getVehicleTypeIds())
     );
   }
 
   @SchemaMapping(typeName = "VehicleTypeCapacity", field = "vehicleType")
   public VehicleType resolveVehicleTypeCapacity(VehicleTypeCapacity vehicleTypeCapacity) {
-    return vehicleTypeCache.get(vehicleTypeCapacity.getVehicleTypeId());
+    return vehicleTypeReader.get(vehicleTypeCapacity.getVehicleTypeId());
   }
 
   @SchemaMapping(typeName = "VehicleTypesCapacity", field = "vehicleTypes")
   public List<VehicleType> resolveVehicleTypesCapacity(
     VehicleTypesCapacity vehicleTypesCapacity
   ) {
-    return vehicleTypeCache.getAll(
+    return vehicleTypeReader.getAll(
       new HashSet<>(vehicleTypesCapacity.getVehicleTypeIds())
     );
   }
@@ -55,7 +55,7 @@ public class StationVehicleTypeResolver {
   public List<VehicleType> resolveVehicleDocksCapacity(
     VehicleDocksCapacity vehicleDocksCapacity
   ) {
-    return vehicleTypeCache.getAll(
+    return vehicleTypeReader.getAll(
       new HashSet<>(vehicleDocksCapacity.getVehicleTypeIds())
     );
   }

--- a/src/main/java/org/entur/lamassu/graphql/resolver/vehicle/VehiclePricingPlanResolver.java
+++ b/src/main/java/org/entur/lamassu/graphql/resolver/vehicle/VehiclePricingPlanResolver.java
@@ -1,6 +1,6 @@
 package org.entur.lamassu.graphql.resolver.vehicle;
 
-import org.entur.lamassu.cache.EntityCache;
+import org.entur.lamassu.cache.EntityReader;
 import org.entur.lamassu.model.entities.PricingPlan;
 import org.entur.lamassu.model.entities.Vehicle;
 import org.entur.lamassu.model.entities.VehicleType;
@@ -10,25 +10,25 @@ import org.springframework.stereotype.Controller;
 @Controller
 public class VehiclePricingPlanResolver {
 
-  private final EntityCache<PricingPlan> pricingPlanCache;
-  private final EntityCache<VehicleType> vehicleTypeCache;
+  private final EntityReader<PricingPlan> pricingPlanReader;
+  private final EntityReader<VehicleType> vehicleTypeReader;
 
   public VehiclePricingPlanResolver(
-    EntityCache<PricingPlan> pricingPlanCache,
-    EntityCache<VehicleType> vehicleTypeCache
+    EntityReader<PricingPlan> pricingPlanReader,
+    EntityReader<VehicleType> vehicleTypeReader
   ) {
-    this.pricingPlanCache = pricingPlanCache;
-    this.vehicleTypeCache = vehicleTypeCache;
+    this.pricingPlanReader = pricingPlanReader;
+    this.vehicleTypeReader = vehicleTypeReader;
   }
 
   @SchemaMapping(typeName = "Vehicle", field = "pricingPlan")
   public PricingPlan resolve(Vehicle vehicle) {
     // pricingPlanId is optional for vehicles and defaults to it's vehicleType's default pricing plan
     if (vehicle.getPricingPlanId() == null) {
-      return pricingPlanCache.get(
-        vehicleTypeCache.get(vehicle.getVehicleTypeId()).getDefaultPricingPlanId()
+      return pricingPlanReader.get(
+        vehicleTypeReader.get(vehicle.getVehicleTypeId()).getDefaultPricingPlanId()
       );
     }
-    return pricingPlanCache.get(vehicle.getPricingPlanId());
+    return pricingPlanReader.get(vehicle.getPricingPlanId());
   }
 }

--- a/src/main/java/org/entur/lamassu/graphql/resolver/vehicle/VehicleSystemResolver.java
+++ b/src/main/java/org/entur/lamassu/graphql/resolver/vehicle/VehicleSystemResolver.java
@@ -1,6 +1,6 @@
 package org.entur.lamassu.graphql.resolver.vehicle;
 
-import org.entur.lamassu.cache.EntityCache;
+import org.entur.lamassu.cache.EntityReader;
 import org.entur.lamassu.model.entities.System;
 import org.entur.lamassu.model.entities.Vehicle;
 import org.springframework.graphql.data.method.annotation.SchemaMapping;
@@ -9,14 +9,14 @@ import org.springframework.stereotype.Controller;
 @Controller
 public class VehicleSystemResolver {
 
-  private final EntityCache<System> systemCache;
+  private final EntityReader<System> systemReader;
 
-  public VehicleSystemResolver(EntityCache<System> systemCache) {
-    this.systemCache = systemCache;
+  public VehicleSystemResolver(EntityReader<System> systemReader) {
+    this.systemReader = systemReader;
   }
 
   @SchemaMapping(typeName = "Vehicle", field = "system")
   public System resolve(Vehicle vehicle) {
-    return systemCache.get(vehicle.getSystemId());
+    return systemReader.get(vehicle.getSystemId());
   }
 }

--- a/src/main/java/org/entur/lamassu/graphql/resolver/vehicle/VehicleTypeResolver.java
+++ b/src/main/java/org/entur/lamassu/graphql/resolver/vehicle/VehicleTypeResolver.java
@@ -1,6 +1,6 @@
 package org.entur.lamassu.graphql.resolver.vehicle;
 
-import org.entur.lamassu.cache.EntityCache;
+import org.entur.lamassu.cache.EntityReader;
 import org.entur.lamassu.model.entities.Vehicle;
 import org.entur.lamassu.model.entities.VehicleType;
 import org.springframework.graphql.data.method.annotation.SchemaMapping;
@@ -9,14 +9,14 @@ import org.springframework.stereotype.Controller;
 @Controller
 public class VehicleTypeResolver {
 
-  private final EntityCache<VehicleType> vehicleTypeCache;
+  private final EntityReader<VehicleType> vehicleTypeReader;
 
-  public VehicleTypeResolver(EntityCache<VehicleType> vehicleTypeCache) {
-    this.vehicleTypeCache = vehicleTypeCache;
+  public VehicleTypeResolver(EntityReader<VehicleType> vehicleTypeReader) {
+    this.vehicleTypeReader = vehicleTypeReader;
   }
 
   @SchemaMapping(typeName = "Vehicle", field = "vehicleType")
   public VehicleType resolve(Vehicle vehicle) {
-    return vehicleTypeCache.get(vehicle.getVehicleTypeId());
+    return vehicleTypeReader.get(vehicle.getVehicleTypeId());
   }
 }

--- a/src/main/java/org/entur/lamassu/graphql/resolver/vehicletype/VehicleTypePricingPlanResolver.java
+++ b/src/main/java/org/entur/lamassu/graphql/resolver/vehicletype/VehicleTypePricingPlanResolver.java
@@ -34,6 +34,6 @@ public class VehicleTypePricingPlanResolver {
       .getPricingPlanIds()
       .stream()
       .map(pricingPlanReader::get)
-      .collect(Collectors.toList());
+      .toList();
   }
 }

--- a/src/main/java/org/entur/lamassu/graphql/resolver/vehicletype/VehicleTypePricingPlanResolver.java
+++ b/src/main/java/org/entur/lamassu/graphql/resolver/vehicletype/VehicleTypePricingPlanResolver.java
@@ -30,10 +30,6 @@ public class VehicleTypePricingPlanResolver {
     if (vehicleType.getPricingPlanIds() == null) {
       return null;
     }
-    return vehicleType
-      .getPricingPlanIds()
-      .stream()
-      .map(pricingPlanReader::get)
-      .toList();
+    return vehicleType.getPricingPlanIds().stream().map(pricingPlanReader::get).toList();
   }
 }

--- a/src/main/java/org/entur/lamassu/graphql/resolver/vehicletype/VehicleTypePricingPlanResolver.java
+++ b/src/main/java/org/entur/lamassu/graphql/resolver/vehicletype/VehicleTypePricingPlanResolver.java
@@ -2,7 +2,7 @@ package org.entur.lamassu.graphql.resolver.vehicletype;
 
 import java.util.List;
 import java.util.stream.Collectors;
-import org.entur.lamassu.cache.EntityCache;
+import org.entur.lamassu.cache.EntityReader;
 import org.entur.lamassu.model.entities.PricingPlan;
 import org.entur.lamassu.model.entities.VehicleType;
 import org.springframework.graphql.data.method.annotation.SchemaMapping;
@@ -11,18 +11,18 @@ import org.springframework.stereotype.Controller;
 @Controller
 public class VehicleTypePricingPlanResolver {
 
-  private final EntityCache<PricingPlan> pricingPlanCache;
+  private final EntityReader<PricingPlan> pricingPlanReader;
 
-  public VehicleTypePricingPlanResolver(EntityCache<PricingPlan> pricingPlanCache) {
-    this.pricingPlanCache = pricingPlanCache;
+  public VehicleTypePricingPlanResolver(EntityReader<PricingPlan> pricingPlanReader) {
+    this.pricingPlanReader = pricingPlanReader;
   }
 
   @SchemaMapping(typeName = "VehicleType", field = "defaultPricingPlan")
-  public PricingPlan defaultPricingPlan(VehicleType vehicleType) {
+  public PricingPlan resolve(VehicleType vehicleType) {
     if (vehicleType.getDefaultPricingPlanId() == null) {
       return null;
     }
-    return pricingPlanCache.get(vehicleType.getDefaultPricingPlanId());
+    return pricingPlanReader.get(vehicleType.getDefaultPricingPlanId());
   }
 
   @SchemaMapping(typeName = "VehicleType", field = "pricingPlans")
@@ -30,8 +30,10 @@ public class VehicleTypePricingPlanResolver {
     if (vehicleType.getPricingPlanIds() == null) {
       return null;
     }
-    return pricingPlanCache.getAll(
-      vehicleType.getPricingPlanIds().stream().collect(Collectors.toSet())
-    );
+    return vehicleType
+      .getPricingPlanIds()
+      .stream()
+      .map(pricingPlanReader::get)
+      .collect(Collectors.toList());
   }
 }


### PR DESCRIPTION
### Summary

Adds request scoped caching of entity lookups - should remedy some of the performance hit in graphql 
queries introduced by #596. This also involves adding a separate interface for reading entities from the cache "EntityReader". 

Improves query performance by an order of magnitude in initial testing

### Issue

#614 