### PR TITLE
fix: remove spring devtools, not used, and causes problems due to kryo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,12 +79,6 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-devtools</artifactId>
-            <scope>runtime</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-core</artifactId>
         </dependency>


### PR DESCRIPTION
### Summary

Problem described here #155 has become more prevalent in changes introduced in #619 and #543. Since we don't use devtools actively in this project, we might as well just remove it entirely from the dependencies.

### Issue

Closes #155