### PR TITLE
Only filter out vehicles that are assigned to non-virtual stations

### DIFF
--- a/src/main/java/org/entur/lamassu/leader/entityupdater/VehicleFilter.java
+++ b/src/main/java/org/entur/lamassu/leader/entityupdater/VehicleFilter.java
@@ -39,7 +39,7 @@ class VehicleFilter implements Predicate<GBFSVehicle> {
   private final EntityCache<Station> stationCache;
 
   @Value(
-    "#{new Boolean('${org.entur.lamssu.vehicle-filter.include-vehicles-assigned-to-non-virtual-stations:false}')}"
+    "#{new Boolean('${org.entur.lamassu.vehicle-filter.include-vehicles-assigned-to-non-virtual-stations:false}')}"
   )
   private Boolean includeVehiclesAssignedToNonVirtualStations;
 

--- a/src/main/java/org/entur/lamassu/leader/entityupdater/VehicleFilter.java
+++ b/src/main/java/org/entur/lamassu/leader/entityupdater/VehicleFilter.java
@@ -39,9 +39,9 @@ class VehicleFilter implements Predicate<GBFSVehicle> {
   private final EntityCache<Station> stationCache;
 
   @Value(
-    "#{new Boolean('${org.entur.lamassu.vehicle-filter.include-vehicles-assigned-to-non-virtual-stations:false}')}"
+    "${org.entur.lamassu.vehicle-filter.include-vehicles-assigned-to-non-virtual-stations:false}"
   )
-  private Boolean includeVehiclesAssignedToNonVirtualStations;
+  private boolean includeVehiclesAssignedToNonVirtualStations;
 
   public VehicleFilter(
     EntityCache<PricingPlan> pricingPlanCache,

--- a/src/main/java/org/entur/lamassu/leader/entityupdater/VehicleFilter.java
+++ b/src/main/java/org/entur/lamassu/leader/entityupdater/VehicleFilter.java
@@ -26,6 +26,7 @@ import org.entur.lamassu.model.entities.VehicleType;
 import org.mobilitydata.gbfs.v3_0.vehicle_status.GBFSVehicle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -36,6 +37,11 @@ class VehicleFilter implements Predicate<GBFSVehicle> {
   private final EntityCache<PricingPlan> pricingPlanCache;
   private final EntityCache<VehicleType> vehicleTypeCache;
   private final EntityCache<Station> stationCache;
+
+  @Value(
+    "#{new Boolean('${org.entur.lamssu.vehicle-filter.include-vehicles-assigned-to-non-virtual-stations:false}')}"
+  )
+  private Boolean includeVehiclesAssignedToNonVirtualStations;
 
   public VehicleFilter(
     EntityCache<PricingPlan> pricingPlanCache,
@@ -51,7 +57,11 @@ class VehicleFilter implements Predicate<GBFSVehicle> {
   public boolean test(GBFSVehicle vehicle) {
     if (vehicle.getStationId() != null) {
       var station = stationCache.get(vehicle.getStationId());
-      if (station != null && !station.getVirtualStation()) {
+      if (
+        station != null &&
+        !station.getVirtualStation() &&
+        !includeVehiclesAssignedToNonVirtualStations
+      ) {
         logger.info(
           "Skipping vehicle {} currently assigned to non-virtual station {}",
           vehicle.getVehicleId(),

--- a/src/test/java/org/entur/lamassu/leader/entityupdater/VehicleFilterTest.java
+++ b/src/test/java/org/entur/lamassu/leader/entityupdater/VehicleFilterTest.java
@@ -2,6 +2,7 @@ package org.entur.lamassu.leader.entityupdater;
 
 import java.util.HashMap;
 import org.entur.lamassu.model.entities.PricingPlan;
+import org.entur.lamassu.model.entities.Station;
 import org.entur.lamassu.model.entities.VehicleType;
 import org.entur.lamassu.stubs.EntityCacheStub;
 import org.junit.Test;
@@ -26,10 +27,11 @@ public class VehicleFilterTest {
   public void testVehicleWithoutPricingPlanButDefaultPricingPlanIsntSkipped() {
     var pricingPlanCache = new EntityCacheStub<PricingPlan>();
     var vehicleTypeCache = new EntityCacheStub<VehicleType>();
+    var stationCache = new EntityCacheStub<Station>();
 
     vehicleTypeCache.updateAll(vehicleTypesWithPricingPlan("pricingPlanId"), 0, null);
 
-    VehicleFilter filter = new VehicleFilter(pricingPlanCache, vehicleTypeCache);
+    VehicleFilter filter = new VehicleFilter(pricingPlanCache, vehicleTypeCache, stationCache);
 
     GBFSVehicle vehicle = new GBFSVehicle();
     vehicle.setVehicleId("VehicleWithoutPricingPlan");
@@ -42,10 +44,11 @@ public class VehicleFilterTest {
   public void testVehicleWithoutPricingPlanAndWithoutDefaultPricingPlanIsSkipped() {
     var pricingPlanCache = new EntityCacheStub<PricingPlan>();
     var vehicleTypeCache = new EntityCacheStub<VehicleType>();
+    var stationCache = new EntityCacheStub<Station>();
 
     vehicleTypeCache.updateAll(vehicleTypesWithPricingPlan(null), 0, null);
 
-    VehicleFilter filter = new VehicleFilter(pricingPlanCache, vehicleTypeCache);
+    VehicleFilter filter = new VehicleFilter(pricingPlanCache, vehicleTypeCache, stationCache);
 
     GBFSVehicle vehicle = new GBFSVehicle();
     vehicle.setVehicleId("VehicleWithoutPricingPlan");

--- a/src/test/java/org/entur/lamassu/leader/entityupdater/VehicleFilterTest.java
+++ b/src/test/java/org/entur/lamassu/leader/entityupdater/VehicleFilterTest.java
@@ -31,7 +31,11 @@ public class VehicleFilterTest {
 
     vehicleTypeCache.updateAll(vehicleTypesWithPricingPlan("pricingPlanId"), 0, null);
 
-    VehicleFilter filter = new VehicleFilter(pricingPlanCache, vehicleTypeCache, stationCache);
+    VehicleFilter filter = new VehicleFilter(
+      pricingPlanCache,
+      vehicleTypeCache,
+      stationCache
+    );
 
     GBFSVehicle vehicle = new GBFSVehicle();
     vehicle.setVehicleId("VehicleWithoutPricingPlan");
@@ -48,7 +52,11 @@ public class VehicleFilterTest {
 
     vehicleTypeCache.updateAll(vehicleTypesWithPricingPlan(null), 0, null);
 
-    VehicleFilter filter = new VehicleFilter(pricingPlanCache, vehicleTypeCache, stationCache);
+    VehicleFilter filter = new VehicleFilter(
+      pricingPlanCache,
+      vehicleTypeCache,
+      stationCache
+    );
 
     GBFSVehicle vehicle = new GBFSVehicle();
     vehicle.setVehicleId("VehicleWithoutPricingPlan");

--- a/src/test/java/org/entur/lamassu/leader/entityupdater/VehicleFilterTest.java
+++ b/src/test/java/org/entur/lamassu/leader/entityupdater/VehicleFilterTest.java
@@ -1,16 +1,37 @@
 package org.entur.lamassu.leader.entityupdater;
 
 import java.util.HashMap;
+import java.util.Map;
 import org.entur.lamassu.model.entities.PricingPlan;
 import org.entur.lamassu.model.entities.Station;
 import org.entur.lamassu.model.entities.VehicleType;
 import org.entur.lamassu.stubs.EntityCacheStub;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mobilitydata.gbfs.v3_0.vehicle_status.GBFSVehicle;
+import org.springframework.test.util.ReflectionTestUtils;
 
-public class VehicleFilterTest {
+class VehicleFilterTest {
 
-  private static String VEHICLE_TYPE_ID = "vehicleTypeId";
+  private static final String VEHICLE_TYPE_ID = "vehicleTypeId";
+
+  private VehicleFilter filter;
+  private EntityCacheStub<PricingPlan> pricingPlanCache;
+  private EntityCacheStub<VehicleType> vehicleTypeCache;
+  private EntityCacheStub<Station> stationCache;
+
+  @BeforeEach
+  public void setUp() {
+    pricingPlanCache = new EntityCacheStub<>();
+    vehicleTypeCache = new EntityCacheStub<>();
+    stationCache = new EntityCacheStub<>();
+    filter = new VehicleFilter(pricingPlanCache, vehicleTypeCache, stationCache);
+    ReflectionTestUtils.setField(
+      filter,
+      "includeVehiclesAssignedToNonVirtualStations",
+      false
+    );
+  }
 
   private HashMap<String, VehicleType> vehicleTypesWithPricingPlan(
     String optionalPricingPlanId
@@ -24,44 +45,113 @@ public class VehicleFilterTest {
   }
 
   @Test
-  public void testVehicleWithoutPricingPlanButDefaultPricingPlanIsntSkipped() {
-    var pricingPlanCache = new EntityCacheStub<PricingPlan>();
-    var vehicleTypeCache = new EntityCacheStub<VehicleType>();
-    var stationCache = new EntityCacheStub<Station>();
-
+  void testVehicleWithoutPricingPlanButDefaultPricingPlanIsntSkipped() {
     vehicleTypeCache.updateAll(vehicleTypesWithPricingPlan("pricingPlanId"), 0, null);
-
-    VehicleFilter filter = new VehicleFilter(
-      pricingPlanCache,
-      vehicleTypeCache,
-      stationCache
-    );
 
     GBFSVehicle vehicle = new GBFSVehicle();
     vehicle.setVehicleId("VehicleWithoutPricingPlan");
     vehicle.setVehicleTypeId(VEHICLE_TYPE_ID);
 
-    assert filter.test(vehicle) == true;
+    assert filter.test(vehicle);
   }
 
   @Test
-  public void testVehicleWithoutPricingPlanAndWithoutDefaultPricingPlanIsSkipped() {
-    var pricingPlanCache = new EntityCacheStub<PricingPlan>();
-    var vehicleTypeCache = new EntityCacheStub<VehicleType>();
-    var stationCache = new EntityCacheStub<Station>();
-
+  void testVehicleWithoutPricingPlanAndWithoutDefaultPricingPlanIsSkipped() {
     vehicleTypeCache.updateAll(vehicleTypesWithPricingPlan(null), 0, null);
-
-    VehicleFilter filter = new VehicleFilter(
-      pricingPlanCache,
-      vehicleTypeCache,
-      stationCache
-    );
 
     GBFSVehicle vehicle = new GBFSVehicle();
     vehicle.setVehicleId("VehicleWithoutPricingPlan");
     vehicle.setVehicleTypeId("vehicleTypeId");
 
-    assert filter.test(vehicle) == false;
+    assert !filter.test(vehicle);
+  }
+
+  @Test
+  void testVehicleWithUnknownPricingPlanIsSkipped() {
+    vehicleTypeCache.updateAll(vehicleTypesWithPricingPlan(null), 0, null);
+
+    GBFSVehicle vehicle = new GBFSVehicle();
+    vehicle.setVehicleId("VehicleWithUnknownPricingPlan");
+    vehicle.setVehicleTypeId(VEHICLE_TYPE_ID);
+    vehicle.setPricingPlanId("unknownPricingPlanId");
+
+    assert !filter.test(vehicle);
+  }
+
+  @Test
+  void testVehicleWithUnknownVehicleTypeIsSkipped() {
+    GBFSVehicle vehicle = new GBFSVehicle();
+    vehicle.setVehicleId("VehicleWithUnknownType");
+    vehicle.setVehicleTypeId("unknownVehicleTypeId");
+
+    assert !filter.test(vehicle);
+  }
+
+  @Test
+  void testVehicleWithValidPricingPlanIsNotSkipped() {
+    String validPricingPlanId = "validPricingPlanId";
+    PricingPlan pricingPlan = new PricingPlan();
+    pricingPlan.setId(validPricingPlanId);
+    Map<String, PricingPlan> pricingPlans = new HashMap<>();
+    pricingPlans.put(validPricingPlanId, pricingPlan);
+    pricingPlanCache.updateAll(pricingPlans, 0, null);
+    vehicleTypeCache.updateAll(vehicleTypesWithPricingPlan(null), 0, null);
+
+    GBFSVehicle vehicle = new GBFSVehicle();
+    vehicle.setVehicleId("VehicleWithValidPricingPlan");
+    vehicle.setVehicleTypeId(VEHICLE_TYPE_ID);
+    vehicle.setPricingPlanId(validPricingPlanId);
+
+    assert filter.test(vehicle);
+  }
+
+  @Test
+  void testVehicleAtNonVirtualStationIsSkippedByDefault() {
+    vehicleTypeCache.updateAll(vehicleTypesWithPricingPlan(null), 0, null);
+
+    String stationId = "nonVirtualStation";
+    Station station = new Station();
+    station.setId(stationId);
+    station.setVirtualStation(false);
+    Map<String, Station> stations = new HashMap<>();
+    stations.put(stationId, station);
+    stationCache.updateAll(stations, 0, null);
+
+    GBFSVehicle vehicle = new GBFSVehicle();
+    vehicle.setVehicleId("VehicleAtNonVirtualStation");
+    vehicle.setVehicleTypeId(VEHICLE_TYPE_ID);
+    vehicle.setStationId(stationId);
+
+    assert !filter.test(vehicle);
+  }
+
+  @Test
+  void testVehicleAtVirtualStationIsNotSkipped() {
+    String defaultPricingPlanId = "defaultPricingPlanId";
+    PricingPlan pricingPlan = new PricingPlan();
+    pricingPlan.setId(defaultPricingPlanId);
+    Map<String, PricingPlan> pricingPlans = new HashMap<>();
+    pricingPlans.put(defaultPricingPlanId, pricingPlan);
+    pricingPlanCache.updateAll(pricingPlans, 0, null);
+    vehicleTypeCache.updateAll(
+      vehicleTypesWithPricingPlan(defaultPricingPlanId),
+      0,
+      null
+    );
+
+    String stationId = "virtualStation";
+    Station station = new Station();
+    station.setId(stationId);
+    station.setVirtualStation(true);
+    Map<String, Station> stations = new HashMap<>();
+    stations.put(stationId, station);
+    stationCache.updateAll(stations, 0, null);
+
+    GBFSVehicle vehicle = new GBFSVehicle();
+    vehicle.setVehicleId("VehicleAtVirtualStation");
+    vehicle.setVehicleTypeId(VEHICLE_TYPE_ID);
+    vehicle.setStationId(stationId);
+
+    assert filter.test(vehicle);
   }
 }


### PR DESCRIPTION
### Summary

The vehicle filter's behavior to filter out vehicles that are assigned to a station, is founded on the assumption that users need to interact with the station's infrastructure in order to rent it. This did not account for virtual stations, which don't have physical infrastructure. This PR narrows down the filtering, so only vehicles that are assigned to a non-virtual station are filtered out.

In addition, configuration is added to opt-out of this filtering behavior.