### PR TITLE
Upgrade base docker image (java version)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -289,7 +289,7 @@
                 </dependencies>
                 <configuration>
                     <from>
-                        <image>eclipse-temurin:21.0.1_12-jre</image>
+                        <image>eclipse-temurin:21.0.5_11-jre</image>
                         <platforms>
                             <platform>
                                 <architecture>amd64</architecture>


### PR DESCRIPTION
### Summary

Upgrades base image / java version for jib to 21.0.5_11. For some reason, renovate doesn't pick this up.
