### PR TITLE
Dedupe codespaces list

### DIFF
--- a/src/main/java/org/entur/lamassu/service/impl/FeedProviderServiceImpl.java
+++ b/src/main/java/org/entur/lamassu/service/impl/FeedProviderServiceImpl.java
@@ -82,7 +82,11 @@ public class FeedProviderServiceImpl implements FeedProviderService {
 
   @Override
   public List<String> getCodespaces() {
-    return getFeedProviders().stream().map(FeedProvider::getCodespace).toList();
+    return getFeedProviders()
+      .stream()
+      .map(FeedProvider::getCodespace)
+      .distinct()
+      .toList();
   }
 
   @Override


### PR DESCRIPTION
### Summary

A recent regression causes duplicate codespaces to be returned by the codespaces query. This PR fixes it.

### Issue

Closes #622 