### PR TITLE
Fixes remove entities from cache after refactoring

### DIFF
--- a/src/main/java/org/entur/lamassu/cache/impl/EntityCacheImpl.java
+++ b/src/main/java/org/entur/lamassu/cache/impl/EntityCacheImpl.java
@@ -72,7 +72,8 @@ abstract class EntityCacheImpl<T extends Entity> implements EntityCache<T> {
 
   @Override
   public void removeAll(Set<String> keys) {
-    cache.fastRemoveAsync(String.valueOf(keys));
+    String[] arr = keys.toArray(String[]::new);
+    cache.fastRemoveAsync(arr);
   }
 
   @Override


### PR DESCRIPTION
### Summary

Recent refactoring introduced a regression in removal of entities in the cache. Currently, no entities are removed because of this error: instead of an error of keys we send Set#toString.

The result of this is that entities are never removed but build up over time.