### PR TITLE
Fix: in VehicleFilter, support is_virtual_station being optional

### DIFF
--- a/src/main/java/org/entur/lamassu/leader/entityupdater/VehicleFilter.java
+++ b/src/main/java/org/entur/lamassu/leader/entityupdater/VehicleFilter.java
@@ -59,7 +59,9 @@ public class VehicleFilter implements Predicate<GBFSVehicle> {
       var station = stationCache.get(vehicle.getStationId());
       if (
         station != null &&
-        !station.getVirtualStation() &&
+        // is_virtual_station may be unset, which we treat as implicitly being false
+        // though spec does not state this as default.
+        !Boolean.TRUE.equals(station.getVirtualStation()) &&
         !includeVehiclesAssignedToNonVirtualStations
       ) {
         logger.info(

--- a/src/test/java/org/entur/lamassu/leader/entityupdater/VehicleFilterTest.java
+++ b/src/test/java/org/entur/lamassu/leader/entityupdater/VehicleFilterTest.java
@@ -154,4 +154,34 @@ class VehicleFilterTest {
 
     assert filter.test(vehicle);
   }
+
+  @Test
+  void testVehicleAtStationWithoutIsVirtualSetIsSkipped() {
+    String defaultPricingPlanId = "defaultPricingPlanId";
+    PricingPlan pricingPlan = new PricingPlan();
+    pricingPlan.setId(defaultPricingPlanId);
+    Map<String, PricingPlan> pricingPlans = new HashMap<>();
+    pricingPlans.put(defaultPricingPlanId, pricingPlan);
+    pricingPlanCache.updateAll(pricingPlans, 0, null);
+    vehicleTypeCache.updateAll(
+      vehicleTypesWithPricingPlan(defaultPricingPlanId),
+      0,
+      null
+    );
+
+    String stationId = "virtualStation";
+    Station station = new Station();
+    station.setId(stationId);
+    station.setVirtualStation(null);
+    Map<String, Station> stations = new HashMap<>();
+    stations.put(stationId, station);
+    stationCache.updateAll(stations, 0, null);
+
+    GBFSVehicle vehicle = new GBFSVehicle();
+    vehicle.setVehicleId("VehicleAtVirtualStation");
+    vehicle.setVehicleTypeId(VEHICLE_TYPE_ID);
+    vehicle.setStationId(stationId);
+
+    assert !filter.test(vehicle);
+  }
 }


### PR DESCRIPTION
### Summary

This PR, in `VehicleFilter`, treats a missing `is_virtual_station` as having a default of `false`.

### Issue

Fixes #655

### Unit tests

Added unit test to demonstrate the issue and fix.

### Documentation
No.

### Changelog

Done.

### Bumping the serialization version id
No.