### PR TITLE
Fix: app config renamings [skip changelog]

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,8 @@ based on merged pull requests. Search GitHub issues and pull requests for smalle
 - Improve: introduce configurable stationEntityCacheMinimumTtl and stationEntityCacheMaximumTtl [#542](https://github.com/entur/lamassu/pull/542)
 - Update subscription immediately after registration [#592](https://github.com/entur/lamassu/pull/592)
 - Replace graphql kickstart project with spring graphql [#595](https://github.com/entur/lamassu/pull/595)
+  - Note: requires `application.properties` change from `graphql.graphiql.enabled` to `spring.graphql.graphiql.enabled`
+  - Note: removes support for graphql requests via http method GET. Use POST instead.
 - Normalize entity data [#596](https://github.com/entur/lamassu/pull/596)
 - Add null checks to avoid NPE [#612](https://github.com/entur/lamassu/pull/612)
 - Remove redundant entity cache interfaces [#613](https://github.com/entur/lamassu/pull/613)

--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,8 @@ based on merged pull requests. Search GitHub issues and pull requests for smalle
 - Remove redundant entity cache interfaces [#613](https://github.com/entur/lamassu/pull/613)
 - Add request-scope cache for reading entities [#619](https://github.com/entur/lamassu/pull/619)
 - Only filter out vehicles that are assigned to non-virtual stations [#626](https://github.com/entur/lamassu/pull/626)
+  - Note: requires `application.properties` change from `org.entur.lamassu.excludeVirtualStations` to
+    `org.entur.lamassu.vehicle-filter.include-vehicles-assigned-to-non-virtual-stations`
 - Dedupe codespaces list [#630](https://github.com/entur/lamassu/pull/630)
 - Compute delta of GBFS files and refactor vehicles and stations updaters [#543](https://github.com/entur/lamassu/pull/543)
 - Fixes remove entities from cache after refactoring [#632](https://github.com/entur/lamassu/pull/632)

--- a/docker-compose/application-config/application.properties
+++ b/docker-compose/application-config/application.properties
@@ -21,7 +21,7 @@ org.entur.lamassu.redis.slave.enabled=false
 #org.entur.lamassu.redis.slave.port=
 
 # graphql starter
-graphiql.enabled=true
+spring.graphql.graphiql.enabled=true
 graphql.servlet.actuator-metrics=true
 graphql.servlet.corsEnabled=false
 

--- a/docker-compose/application-config/application.properties
+++ b/docker-compose/application-config/application.properties
@@ -56,4 +56,4 @@ org.entur.lamassu.serializationVersion=1
 org.entur.lamassu.enableValidation=true
 
 ## Control filtering of virtual stations
-org.entur.lamassu.excludeVirtualStations=false
+org.entur.lamassu.vehicle-filter.include-vehicles-assigned-to-non-virtual-stations=false

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -31,3 +31,6 @@ spring.profiles.active=leader
 
 org.entur.lamassu.enableValidation=true
 # org.entur.lamassu.gbfs.cache-control.minimum-ttl=10
+
+## Control filtering of virtual stations
+org.entur.lamassu.vehicle-filter.include-vehicles-assigned-to-non-virtual-stations=false

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,7 +13,7 @@ management.health.redis.enabled=true
 #spring.redis.host=localhost
 #spring.redis.port=localhost
 
-graphql.graphiql.enabled=true
+spring.graphql.graphiql.enabled=true
 
 org.entur.lamassu.feedproviders=classpath:feedproviders.yml
 org.entur.lamassu.targetLanguageCode=nb


### PR DESCRIPTION
### Summary

This PR updates two `application.properties` config param names and adds a note to the Changelog to make these config changes explicit.

### Issue

fixes #657 

### Unit tests

None
### Documentation

Added notes to existing changelog (that's why I added `skip changelog`  to this PR).

