### PR TITLE
feat: add metric for outdated feeds

### DIFF
--- a/src/main/java/org/entur/lamassu/leader/LeaderSingletonService.java
+++ b/src/main/java/org/entur/lamassu/leader/LeaderSingletonService.java
@@ -2,6 +2,7 @@ package org.entur.lamassu.leader;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
+import org.entur.lamassu.metrics.MetricUpdater;
 import org.entur.lamassu.service.GeoSearchService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,13 +21,16 @@ public class LeaderSingletonService {
   private final Logger logger = LoggerFactory.getLogger(this.getClass());
   private final FeedUpdater feedUpdater;
   private final GeoSearchService geoSearchService;
+  private final MetricUpdater metricUpdater;
 
   public LeaderSingletonService(
     @Autowired FeedUpdater feedUpdater,
-    @Autowired GeoSearchService geoSearchService
+    @Autowired GeoSearchService geoSearchService,
+    @Autowired MetricUpdater metricUpdater
   ) {
     this.feedUpdater = feedUpdater;
     this.geoSearchService = geoSearchService;
+    this.metricUpdater = metricUpdater;
   }
 
   @PostConstruct
@@ -52,5 +56,10 @@ public class LeaderSingletonService {
     if (!removedOrphans.isEmpty()) {
       logger.info("Removed {} orphans in vehicle spatial index", removedOrphans.size());
     }
+  }
+
+  @Scheduled(fixedRateString = "${org.entur.lamassu.update-feed-metrics-interval:60000}")
+  public void updateFeedMetrics() {
+    metricUpdater.updateOutdatedFeedMetrics();
   }
 }

--- a/src/main/java/org/entur/lamassu/metrics/MetricUpdater.java
+++ b/src/main/java/org/entur/lamassu/metrics/MetricUpdater.java
@@ -1,0 +1,76 @@
+package org.entur.lamassu.metrics;
+
+import java.lang.reflect.InvocationTargetException;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Date;
+import org.entur.lamassu.cache.GBFSV3FeedCache;
+import org.entur.lamassu.config.feedprovider.FeedProviderConfig;
+import org.entur.lamassu.model.provider.FeedProvider;
+import org.mobilitydata.gbfs.v3_0.gbfs.GBFSFeed;
+import org.mobilitydata.gbfs.v3_0.gbfs.GBFSFeedName;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MetricUpdater {
+
+  @Value("${org.entur.lamassu.max-tolerated-overdue-seconds:120}")
+  private Integer maxToleratedOverdueSeconds = 120;
+
+  private final MetricsService metricsService;
+  private final FeedProviderConfig feedProviderConfig;
+  private final GBFSV3FeedCache feedCache;
+
+  @Autowired
+  public MetricUpdater(
+    MetricsService metricsService,
+    FeedProviderConfig feedProviderConfig,
+    GBFSV3FeedCache feedCache
+  ) {
+    this.metricsService = metricsService;
+    this.feedProviderConfig = feedProviderConfig;
+    this.feedCache = feedCache;
+  }
+
+  public void updateOutdatedFeedMetrics() {
+    feedProviderConfig
+      .getProviders()
+      .parallelStream()
+      .forEach(this::updateOutdatedFeedMetrics);
+  }
+
+  private void updateOutdatedFeedMetrics(FeedProvider feedProvider) {
+    int overdueFilesCount = Arrays
+      .asList(GBFSFeed.Name.values())
+      .stream()
+      // TODO as gbfs is not yet updated regularly, we skip it explicitly
+      .filter(feedName -> !GBFSFeed.Name.GBFS.equals(feedName))
+      .mapToInt(feedName -> isFeedOverdue(feedProvider, feedName) ? 1 : 0)
+      .sum();
+
+    metricsService.registerOverdueFilesCount(feedProvider, overdueFilesCount);
+  }
+
+  private boolean isFeedOverdue(FeedProvider feedProvider, GBFSFeed.Name feedName) {
+    Object feed = feedCache.find(feedName, feedProvider);
+    if (feed != null) {
+      long absoluteTtl = getAbsoluteTtl(GBFSFeedName.implementingClass(feedName), feed);
+      return absoluteTtl + maxToleratedOverdueSeconds < Instant.now().getEpochSecond();
+    }
+    return false;
+  }
+
+  private <T> long getAbsoluteTtl(Class<?> feedClass, T feed) {
+    try {
+      Date lastUpdated = (Date) feedClass.getMethod("getLastUpdated").invoke(feed);
+      Integer ttl = (Integer) feedClass.getMethod("getTtl").invoke(feed);
+      return lastUpdated.getTime() / 1000 + ttl;
+    } catch (
+      NoSuchMethodException | InvocationTargetException | IllegalAccessException e
+    ) {
+      return 0;
+    }
+  }
+}

--- a/src/main/java/org/entur/lamassu/metrics/MetricUpdater.java
+++ b/src/main/java/org/entur/lamassu/metrics/MetricUpdater.java
@@ -45,7 +45,7 @@ public class MetricUpdater {
     int overdueFilesCount = Arrays
       .asList(GBFSFeed.Name.values())
       .stream()
-      // TODO as gbfs is not yet updated regularly, we skip it explicitly
+      // Since gbfs is not yet updated regularly, we skip it explicitly
       .filter(feedName -> !GBFSFeed.Name.GBFS.equals(feedName))
       .mapToInt(feedName -> isFeedOverdue(feedProvider, feedName) ? 1 : 0)
       .sum();

--- a/src/main/java/org/entur/lamassu/metrics/MetricsService.java
+++ b/src/main/java/org/entur/lamassu/metrics/MetricsService.java
@@ -42,6 +42,7 @@ public class MetricsService {
 
   protected static final String SUBSCRIPTION_FAILEDSETUP =
     "app.lamassu.gbfs.subscription.failedsetup";
+  public static final String FILES_OVERDUE = "app.lamassu.gbfs.filesoverdue";
   public static final String LABEL_ENTITY = "entity";
 
   public static final String ENTITY_VEHICLE = "vehicle";
@@ -59,6 +60,8 @@ public class MetricsService {
   private final Map<String, AtomicInteger> validationFeedErrorsCounters =
     new ConcurrentHashMap<>();
   private final Map<String, AtomicInteger> validationMissingRequiredFilesCounters =
+    new ConcurrentHashMap<>();
+  private final Map<String, AtomicInteger> overdueFilesCounters =
     new ConcurrentHashMap<>();
 
   public MetricsService(MeterRegistry meterRegistry) {
@@ -101,6 +104,13 @@ public class MetricsService {
     }
   }
 
+  public void registerOverdueFilesCount(
+    FeedProvider feedProvider,
+    int overdueFilesCount
+  ) {
+    getOverdueFilesCounter(feedProvider).set(overdueFilesCount);
+  }
+
   private AtomicInteger getSubscriptionFailedSetupCounter(FeedProvider feedProvider) {
     return getCounter(
       feedProvider,
@@ -115,6 +125,10 @@ public class MetricsService {
       validationFeedErrorsCounters,
       VALIDATION_MISSING_REQUIRED_FILES
     );
+  }
+
+  private AtomicInteger getOverdueFilesCounter(FeedProvider feedProvider) {
+    return getCounter(feedProvider, overdueFilesCounters, FILES_OVERDUE);
   }
 
   private AtomicInteger getValidationFeedErrorsCounter(FeedProvider feedProvider) {

--- a/src/test/java/org/entur/lamassu/leader/LeaderSingletonServiceTest.java
+++ b/src/test/java/org/entur/lamassu/leader/LeaderSingletonServiceTest.java
@@ -2,6 +2,7 @@ package org.entur.lamassu.leader;
 
 import static org.mockito.Mockito.*;
 
+import org.entur.lamassu.metrics.MetricUpdater;
 import org.entur.lamassu.service.GeoSearchService;
 import org.junit.Test;
 
@@ -9,10 +10,15 @@ public class LeaderSingletonServiceTest {
 
   FeedUpdater mockedFeedUpdater = mock(FeedUpdater.class);
   GeoSearchService mockedGeoSearchService = mock(GeoSearchService.class);
+  MetricUpdater mockedMetricUpdater = mock(MetricUpdater.class);
 
   @Test
   public void testStartsScheduling() {
-    var service = new LeaderSingletonService(mockedFeedUpdater, mockedGeoSearchService);
+    var service = new LeaderSingletonService(
+      mockedFeedUpdater,
+      mockedGeoSearchService,
+      mockedMetricUpdater
+    );
     service.init();
     verify(mockedFeedUpdater).start();
   }

--- a/src/test/java/org/entur/lamassu/metrics/MetricsUpdaterTest.java
+++ b/src/test/java/org/entur/lamassu/metrics/MetricsUpdaterTest.java
@@ -1,0 +1,70 @@
+package org.entur.lamassu.metrics;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Date;
+import java.util.List;
+import org.entur.lamassu.cache.GBFSV3FeedCache;
+import org.entur.lamassu.config.feedprovider.FeedProviderConfig;
+import org.entur.lamassu.model.provider.FeedProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mobilitydata.gbfs.v3_0.gbfs.GBFSFeed;
+import org.mobilitydata.gbfs.v3_0.gbfs.GBFSGbfs;
+import org.mobilitydata.gbfs.v3_0.station_information.GBFSStationInformation;
+
+public class MetricsUpdaterTest {
+
+  MetricsService mockedMetricsService = mock(MetricsService.class);
+  FeedProviderConfig mockedFeedProviderConfig = mock(FeedProviderConfig.class);
+  GBFSV3FeedCache mockedFeedCache = mock(GBFSV3FeedCache.class);
+  MetricUpdater metricUpdater;
+  FeedProvider aFeedProvider = new FeedProvider();
+
+  @BeforeEach
+  public void beforeEach() {
+    aFeedProvider.setSystemId("TestSystem");
+    when(mockedFeedProviderConfig.getProviders()).thenReturn(List.of(aFeedProvider));
+    metricUpdater =
+      new MetricUpdater(mockedMetricsService, mockedFeedProviderConfig, mockedFeedCache);
+  }
+
+  @Test
+  public void testRecentlyUpdatedFileIsNotOverdue() {
+    GBFSStationInformation gbfsStationInformation = new GBFSStationInformation()
+      .withLastUpdated(new Date())
+      .withTtl(0);
+    when(mockedFeedCache.find(GBFSFeed.Name.STATION_INFORMATION, aFeedProvider))
+      .thenReturn(gbfsStationInformation);
+
+    metricUpdater.updateOutdatedFeedMetrics();
+
+    verify(mockedMetricsService).registerOverdueFilesCount(aFeedProvider, 0);
+  }
+
+  @Test
+  public void testOutdatedFileIsOverdue() {
+    GBFSStationInformation gbfsStationInformation = new GBFSStationInformation()
+      .withLastUpdated(new Date(0))
+      .withTtl(0);
+    when(mockedFeedCache.find(GBFSFeed.Name.STATION_INFORMATION, aFeedProvider))
+      .thenReturn(gbfsStationInformation);
+
+    metricUpdater.updateOutdatedFeedMetrics();
+
+    verify(mockedMetricsService).registerOverdueFilesCount(aFeedProvider, 1);
+  }
+
+  @Test
+  public void testOutdatedGbfsFileIsNotCountedAsOverdue() {
+    // As long as gbfs is not updated, we don't include it in overdue count
+    GBFSGbfs gbfs = new GBFSGbfs().withLastUpdated(new Date(0)).withTtl(0);
+    when(mockedFeedCache.find(GBFSFeed.Name.GBFS, aFeedProvider)).thenReturn(gbfs);
+
+    metricUpdater.updateOutdatedFeedMetrics();
+
+    verify(mockedMetricsService).registerOverdueFilesCount(aFeedProvider, 0);
+  }
+}


### PR DESCRIPTION
### Summary

This PR adds a metric `app.lamassu.gbfs.filesoverdue` which reports the number of overdue files per feedProvider.

A file is counted as overdue if
* `lastUpdated` + `ttl` + `${org.entur.lamassu.max-tolerated-overdue-seconds:120}` < `currentSecondsSinceEpoch` and
* it is not the gbfs.json file (this is currently only reloaded on lamassu startup)

### Issue
Closes #341 

### Unit tests

Added a unit test `MetricsUpdaterTest`.

### Documentation

No documentation.
