### PR TITLE
Fix: Use station coords for docked vehicles without coords [bump serialization id]

### DIFF
--- a/src/main/java/org/entur/lamassu/leader/entityupdater/EntityCachesUpdater.java
+++ b/src/main/java/org/entur/lamassu/leader/entityupdater/EntityCachesUpdater.java
@@ -89,23 +89,7 @@ public class EntityCachesUpdater {
       regionsUpdater.update(delivery.systemRegions(), feedProvider.getLanguage());
     }
 
-    if (canUpdateVehicles(delivery, feedProvider)) {
-      var useBase = updateContinuityTracker.hasVehicleUpdateContinuity(
-        feedProvider.getSystemId(),
-        oldDelivery
-      );
-      GBFSFileDelta<GBFSVehicle> vehicleStatusDelta =
-        vehicleStatusDeltaCalculator.calculateDelta(
-          useBase ? oldDelivery.vehicleStatus() : null,
-          delivery.vehicleStatus()
-        );
-      vehiclesUpdater.update(feedProvider, vehicleStatusDelta);
-      updateContinuityTracker.updateVehicleUpdateContinuity(
-        feedProvider.getSystemId(),
-        delivery
-      );
-    }
-
+    // Update stations before vehicles, as vehicles may refer to stations
     if (canUpdateStations(delivery, feedProvider)) {
       var useBase = updateContinuityTracker.hasStationUpdateContinuity(
         feedProvider.getSystemId(),
@@ -122,6 +106,23 @@ public class EntityCachesUpdater {
         delivery.stationInformation()
       );
       updateContinuityTracker.updateStationUpdateContinuity(
+        feedProvider.getSystemId(),
+        delivery
+      );
+    }
+
+    if (canUpdateVehicles(delivery, feedProvider)) {
+      var useBase = updateContinuityTracker.hasVehicleUpdateContinuity(
+        feedProvider.getSystemId(),
+        oldDelivery
+      );
+      GBFSFileDelta<GBFSVehicle> vehicleStatusDelta =
+        vehicleStatusDeltaCalculator.calculateDelta(
+          useBase ? oldDelivery.vehicleStatus() : null,
+          delivery.vehicleStatus()
+        );
+      vehiclesUpdater.update(feedProvider, vehicleStatusDelta);
+      updateContinuityTracker.updateVehicleUpdateContinuity(
         feedProvider.getSystemId(),
         delivery
       );

--- a/src/main/java/org/entur/lamassu/mapper/entitymapper/VehicleMapper.java
+++ b/src/main/java/org/entur/lamassu/mapper/entitymapper/VehicleMapper.java
@@ -19,6 +19,7 @@
 package org.entur.lamassu.mapper.entitymapper;
 
 import java.util.List;
+import org.entur.lamassu.model.entities.Station;
 import org.entur.lamassu.model.entities.Vehicle;
 import org.entur.lamassu.model.entities.VehicleEquipment;
 import org.mobilitydata.gbfs.v3_0.vehicle_status.GBFSVehicle;
@@ -35,11 +36,16 @@ public class VehicleMapper {
     this.rentalUrisMapper = rentalUrisMapper;
   }
 
-  public Vehicle mapVehicle(GBFSVehicle vehicle, String systemId) {
+  public Vehicle mapVehicle(GBFSVehicle vehicle, Station station, String systemId) {
     var mappedVehicle = new Vehicle();
     mappedVehicle.setId(vehicle.getVehicleId());
-    mappedVehicle.setLat(vehicle.getLat());
-    mappedVehicle.setLon(vehicle.getLon());
+    if (vehicle.getLat() == null && vehicle.getLon() == null && station != null) {
+      mappedVehicle.setLat(station.getLat());
+      mappedVehicle.setLon(station.getLon());
+    } else {
+      mappedVehicle.setLat(vehicle.getLat());
+      mappedVehicle.setLon(vehicle.getLon());
+    }
     mappedVehicle.setReserved(vehicle.getIsReserved());
     mappedVehicle.setDisabled(vehicle.getIsDisabled());
     mappedVehicle.setCurrentRangeMeters(
@@ -52,6 +58,7 @@ public class VehicleMapper {
     mappedVehicle.setRentalUris(rentalUrisMapper.mapRentalUris(vehicle.getRentalUris()));
     mappedVehicle.setAvailableUntil(vehicle.getAvailableUntil());
     mappedVehicle.setSystemId(systemId);
+    mappedVehicle.setStationId(vehicle.getStationId());
     return mappedVehicle;
   }
 

--- a/src/main/java/org/entur/lamassu/model/entities/Vehicle.java
+++ b/src/main/java/org/entur/lamassu/model/entities/Vehicle.java
@@ -21,6 +21,7 @@ public class Vehicle implements LocationEntity {
   private String vehicleTypeId;
   private String pricingPlanId;
   private String systemId;
+  private String stationId;
 
   @Override
   public String getId() {
@@ -153,6 +154,14 @@ public class Vehicle implements LocationEntity {
     this.systemId = systemId;
   }
 
+  public String getStationId() {
+    return stationId;
+  }
+
+  public void setStationId(String stationId) {
+    this.stationId = stationId;
+  }
+
   @Override
   public String toString() {
     return (
@@ -186,6 +195,8 @@ public class Vehicle implements LocationEntity {
       system +
       ", rentalUris=" +
       rentalUris +
+      ", stationId=" +
+      stationId +
       '}'
     );
   }

--- a/src/test/java/org/entur/lamassu/mapper/entitymapper/VehicleMapperTest.java
+++ b/src/test/java/org/entur/lamassu/mapper/entitymapper/VehicleMapperTest.java
@@ -1,0 +1,25 @@
+package org.entur.lamassu.mapper.entitymapper;
+
+import static org.junit.Assert.assertEquals;
+
+import org.entur.lamassu.model.entities.Station;
+import org.entur.lamassu.model.entities.Vehicle;
+import org.junit.jupiter.api.Test;
+import org.mobilitydata.gbfs.v3_0.vehicle_status.GBFSVehicle;
+
+public class VehicleMapperTest {
+
+  @Test
+  void dockedVehicleWithoutCoordsShouldInheritStationCoords() {
+    final VehicleMapper vehicleMapper = new VehicleMapper(new RentalUrisMapper());
+    Station station = new Station();
+    station.setId("TST:1");
+    station.setLat(45.0);
+    station.setLon(-110.0);
+
+    GBFSVehicle vehicle = new GBFSVehicle().withStationId("TST:1");
+    final Vehicle mappedVehicle = vehicleMapper.mapVehicle(vehicle, station, "test");
+    assertEquals(station.getLat(), mappedVehicle.getLat());
+    assertEquals(station.getLon(), mappedVehicle.getLon());
+  }
+}


### PR DESCRIPTION
### Summary

This PR sets lat/lon to the vehicle's station coords, if the vehicle is docked and has no coords.

It also adds field `stationId` to `Vehicle` and swaps update order for stations and vehicles: stations should be updated before vehicles, so referenced stations are most likely already in the cache when `VehicleUpdater` looks them up by id.

### Issue

Fixes #661.

### Unit tests

Added two tests:
* `VehicleMapperTest` and 
* `VehicleUpdaterTest.shouldHandleDockedVehicleUpdate()`

### Documentation

/

### Bumping the serialization version id
As Vehicle got additional field `stationId`, i added `bump serialization id` to this PR.