### PR TITLE
Do change enabled status when stopping a subscription

### DIFF
--- a/src/main/java/org/entur/lamassu/leader/FeedUpdater.java
+++ b/src/main/java/org/entur/lamassu/leader/FeedUpdater.java
@@ -294,9 +294,6 @@ public class FeedUpdater {
    * @return true if the subscription was stopped or wasn't running, false if there was an error
    */
   public boolean stopSubscription(FeedProvider feedProvider) {
-    // Disable the feed provider
-    feedProvider.setEnabled(false);
-
     // Check if a subscription exists
     String subscriptionId = subscriptionRegistry.getSubscriptionIdBySystemId(
       feedProvider.getSystemId()

--- a/src/test/java/org/entur/lamassu/integration/AdminControllerIntegrationTest.java
+++ b/src/test/java/org/entur/lamassu/integration/AdminControllerIntegrationTest.java
@@ -139,9 +139,9 @@ class AdminControllerIntegrationTest extends AbstractIntegrationTestBase {
     assertNotNull(statusResponse.getBody());
     assertEquals(SubscriptionStatus.STOPPED, statusResponse.getBody());
 
-    // 7. Verify provider is now disabled in Redis
+    // 7. Verify provider is still enabled in Redis
     provider = feedProviderConfig.getProviderBySystemId(TEST_SYSTEM_ID);
-    assertFalse(provider.getEnabled());
+    assertTrue(provider.getEnabled());
 
     // 8. Restart subscription
     ResponseEntity<Void> restartResponse = restTemplate.exchange(
@@ -169,7 +169,7 @@ class AdminControllerIntegrationTest extends AbstractIntegrationTestBase {
     assertNotNull(statusResponse.getBody());
     assertEquals(SubscriptionStatus.STARTED, statusResponse.getBody());
 
-    // 10. Verify provider is enabled again in Redis
+    // 10. Verify provider is still enabled in Redis
     provider = feedProviderConfig.getProviderBySystemId(TEST_SYSTEM_ID);
     assertTrue(provider.getEnabled());
   }

--- a/src/test/java/org/entur/lamassu/leader/FeedUpdaterSubscriptionTest.java
+++ b/src/test/java/org/entur/lamassu/leader/FeedUpdaterSubscriptionTest.java
@@ -1,6 +1,5 @@
 package org.entur.lamassu.leader;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;

--- a/src/test/java/org/entur/lamassu/leader/FeedUpdaterSubscriptionTest.java
+++ b/src/test/java/org/entur/lamassu/leader/FeedUpdaterSubscriptionTest.java
@@ -164,7 +164,7 @@ class FeedUpdaterSubscriptionTest {
 
     // Assert
     assertTrue(result);
-    assertFalse(testProvider.getEnabled());
+    assertTrue(testProvider.getEnabled());
     verify(subscriptionRegistry)
       .updateSubscriptionStatus(SYSTEM_ID, SubscriptionStatus.STOPPING);
     verify(subscriptionManager).unsubscribe(SUBSCRIPTION_ID);
@@ -181,7 +181,7 @@ class FeedUpdaterSubscriptionTest {
 
     // Assert
     assertTrue(result);
-    assertFalse(testProvider.getEnabled());
+    assertTrue(testProvider.getEnabled());
     verify(subscriptionRegistry)
       .updateSubscriptionStatus(SYSTEM_ID, SubscriptionStatus.STOPPED);
     verify(subscriptionManager, never()).unsubscribe(anyString());


### PR DESCRIPTION
In #679 I introduced the ability to control the lifecycle of subscriptions. However, when stopping a subscription, it also
sets the enabled status to false, which filters out the system from system discovery, but leaves any data intact.

Stopping a subscription should leave the system enabled. Only explicitly disabling should remove data and remove system from system discovery.