### PR TITLE
Protect feed provider config from cache clearing

### DIFF
--- a/src/main/java/org/entur/lamassu/cache/CacheManagementService.java
+++ b/src/main/java/org/entur/lamassu/cache/CacheManagementService.java
@@ -1,0 +1,52 @@
+/*
+ *
+ *
+ *  * Licensed under the EUPL, Version 1.2 or u2013 as soon they will be approved by
+ *  * the European Commission - subsequent versions of the EUPL (the "Licence");
+ *  * You may not use this work except in compliance with the Licence.
+ *  * You may obtain a copy of the Licence at:
+ *  *
+ *  *   https://joinup.ec.europa.eu/software/page/eupl
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the Licence is distributed on an "AS IS" basis,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the Licence for the specific language governing permissions and
+ *  * limitations under the Licence.
+ *
+ */
+
+package org.entur.lamassu.cache;
+
+import java.util.Collection;
+import java.util.List;
+import org.redisson.api.RFuture;
+
+/**
+ * Service interface for managing cache operations.
+ * This includes operations like clearing old caches, listing cache keys,
+ * and other cache management functions.
+ */
+public interface CacheManagementService {
+  /**
+   * Gets all cache keys currently in the cache store.
+   *
+   * @return A collection of all cache keys
+   */
+  Collection<String> getCacheKeys();
+
+  /**
+   * Clears all caches in the system.
+   *
+   * @return A future that completes when the operation is done
+   */
+  RFuture<Void> clearAllCaches();
+
+  /**
+   * Clears old cache entries that are no longer needed.
+   * This preserves essential configuration data that should not be deleted.
+   *
+   * @return A list of keys that were deleted
+   */
+  List<String> clearOldCaches();
+}

--- a/src/main/java/org/entur/lamassu/cache/impl/CacheManagementServiceImpl.java
+++ b/src/main/java/org/entur/lamassu/cache/impl/CacheManagementServiceImpl.java
@@ -1,0 +1,87 @@
+/*
+ *
+ *
+ *  * Licensed under the EUPL, Version 1.2 or u2013 as soon they will be approved by
+ *  * the European Commission - subsequent versions of the EUPL (the "Licence");
+ *  * You may not use this work except in compliance with the Licence.
+ *  * You may obtain a copy of the Licence at:
+ *  *
+ *  *   https://joinup.ec.europa.eu/software/page/eupl
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the Licence is distributed on an "AS IS" basis,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the Licence for the specific language governing permissions and
+ *  * limitations under the Licence.
+ *
+ */
+
+package org.entur.lamassu.cache.impl;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.StreamSupport;
+import org.entur.lamassu.cache.CacheManagementService;
+import org.entur.lamassu.config.feedprovider.FeedProviderConfigRedis;
+import org.entur.lamassu.config.project.LamassuProjectInfoConfiguration;
+import org.redisson.api.RFuture;
+import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+/**
+ * Implementation of the CacheManagementService interface.
+ * This service provides methods for managing cache operations using Redisson.
+ */
+@Service
+public class CacheManagementServiceImpl implements CacheManagementService {
+
+  private final RedissonClient redissonClient;
+  private final String serializationVersion;
+  private final List<String> protectedKeys;
+
+  @Autowired
+  public CacheManagementServiceImpl(
+    RedissonClient redissonClient,
+    LamassuProjectInfoConfiguration lamassuProjectInfoConfiguration
+  ) {
+    this.redissonClient = redissonClient;
+    this.serializationVersion = lamassuProjectInfoConfiguration.getSerializationVersion();
+
+    // Initialize the list of keys that should be protected from deletion
+    this.protectedKeys = new ArrayList<>();
+    this.protectedKeys.add(FeedProviderConfigRedis.FEED_PROVIDERS_REDIS_KEY); // Protect feed provider configuration
+  }
+
+  @Override
+  public Collection<String> getCacheKeys() {
+    return StreamSupport
+      .stream(redissonClient.getKeys().getKeys().spliterator(), false)
+      .toList();
+  }
+
+  @Override
+  public RFuture<Void> clearAllCaches() {
+    return redissonClient.getKeys().flushdbParallelAsync();
+  }
+
+  @Override
+  public List<String> clearOldCaches() {
+    var keys = redissonClient.getKeys();
+    List<String> deletedKeys = new ArrayList<>();
+
+    keys
+      .getKeys()
+      .forEach(key -> {
+        // Skip keys that end with the current serialization version
+        // and keys that are in the protected list
+        if (!key.endsWith("_" + serializationVersion) && !protectedKeys.contains(key)) {
+          keys.delete(key);
+          deletedKeys.add(key);
+        }
+      });
+
+    return deletedKeys;
+  }
+}

--- a/src/main/java/org/entur/lamassu/config/feedprovider/FeedProviderConfigRedis.java
+++ b/src/main/java/org/entur/lamassu/config/feedprovider/FeedProviderConfigRedis.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class FeedProviderConfigRedis implements FeedProviderConfig {
 
-  private static final String FEED_PROVIDERS_REDIS_KEY = "feedProviders";
+  public static final String FEED_PROVIDERS_REDIS_KEY = "feedProviders";
 
   private final RBucket<List<FeedProvider>> feedProvidersBucket;
 

--- a/src/test/java/org/entur/lamassu/integration/AdminControllerIntegrationTest.java
+++ b/src/test/java/org/entur/lamassu/integration/AdminControllerIntegrationTest.java
@@ -37,7 +37,6 @@ class AdminControllerIntegrationTest extends AbstractIntegrationTestBase {
   private SubscriptionRegistry subscriptionRegistry;
 
   private static final String TEST_SYSTEM_ID = "test-system-id";
-  private static final String CACHE_TEST_SYSTEM_ID = "cache-test-system-id";
   private static final String TEST_FEED_URL = "http://localhost:8888/testatlantis/gbfs";
 
   /**
@@ -358,14 +357,5 @@ class AdminControllerIntegrationTest extends AbstractIntegrationTestBase {
 
   private HttpEntity createAuthEntity(Object body) {
     return new HttpEntity<>(body, createAuthHeaders());
-  }
-
-  private FeedProvider createTestFeedProvider() {
-    FeedProvider testProvider = new FeedProvider();
-    testProvider.setSystemId(CACHE_TEST_SYSTEM_ID);
-    testProvider.setUrl(TEST_FEED_URL);
-    testProvider.setLanguage("en");
-    testProvider.setEnabled(false); // Start with disabled
-    return testProvider;
   }
 }


### PR DESCRIPTION

### Summary

Protects feed provider config in redis when clearing old cache keys.

Also refactors AdminController so it must manage the cache via a service instead of using redisson client directly.

### Issue

Closes #696 