### PR TITLE
Enable system hours to opening hours mapping

### DIFF
--- a/src/main/java/org/entur/lamassu/mapper/feedmapper/GbfsFeedVersionMappers.java
+++ b/src/main/java/org/entur/lamassu/mapper/feedmapper/GbfsFeedVersionMappers.java
@@ -58,7 +58,11 @@ public class GbfsFeedVersionMappers {
       GBFSMapper.INSTANCE.map(source.discovery(), languageCode),
       // TODO since we now produce v2.x and v3.x we can generate the versions feed
       null,
-      GBFSMapper.INSTANCE.map(source.systemInformation(), languageCode),
+      GBFSMapper.INSTANCE.map(
+        source.systemInformation(),
+        source.systemHours(),
+        languageCode
+      ),
       GBFSMapper.INSTANCE.map(source.vehicleTypes(), languageCode),
       GBFSMapper.INSTANCE.map(source.stationInformation(), languageCode),
       GBFSMapper.INSTANCE.map(source.stationStatus(), languageCode),


### PR DESCRIPTION
### Summary

Enables mapping v2 system_hours.json to v3 opening_hours field in system_information.json. See https://github.com/entur/gbfs-mapper-java/pull/94
