### PR TITLE
feat: add GraphQL filter for vehicles at non-virtual stations

### DIFF
--- a/src/main/java/org/entur/lamassu/cache/VehicleSpatialIndexId.java
+++ b/src/main/java/org/entur/lamassu/cache/VehicleSpatialIndexId.java
@@ -11,6 +11,7 @@ public class VehicleSpatialIndexId
   private PropulsionType propulsionType;
   private boolean isReserved;
   private boolean isDisabled;
+  private boolean isAtNonVirtualStation;
 
   public FormFactor getFormFactor() {
     return formFactor;
@@ -44,6 +45,14 @@ public class VehicleSpatialIndexId
     isDisabled = disabled;
   }
 
+  public boolean getAtNonVirtualStation() {
+    return isAtNonVirtualStation;
+  }
+
+  public void setAtNonVirtualStation(boolean atNonVirtualStation) {
+    isAtNonVirtualStation = atNonVirtualStation;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
@@ -54,6 +63,7 @@ public class VehicleSpatialIndexId
 
     if (isReserved != that.isReserved) return false;
     if (isDisabled != that.isDisabled) return false;
+    if (isAtNonVirtualStation != that.isAtNonVirtualStation) return false;
     if (formFactor != that.formFactor) return false;
     return propulsionType == that.propulsionType;
   }
@@ -65,6 +75,7 @@ public class VehicleSpatialIndexId
     result = 31 * result + (propulsionType != null ? propulsionType.hashCode() : 0);
     result = 31 * result + (isReserved ? 1 : 0);
     result = 31 * result + (isDisabled ? 1 : 0);
+    result = 31 * result + (isAtNonVirtualStation ? 1 : 0);
     return result;
   }
 }

--- a/src/main/java/org/entur/lamassu/graphql/query/VehicleQueryController.java
+++ b/src/main/java/org/entur/lamassu/graphql/query/VehicleQueryController.java
@@ -12,6 +12,7 @@ import org.entur.lamassu.service.BoundingBoxQueryParameters;
 import org.entur.lamassu.service.GeoSearchService;
 import org.entur.lamassu.service.RangeQueryParameters;
 import org.entur.lamassu.service.VehicleFilterParameters;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.graphql.data.method.annotation.Argument;
 import org.springframework.graphql.data.method.annotation.QueryMapping;
 import org.springframework.stereotype.Controller;
@@ -22,15 +23,21 @@ public class VehicleQueryController {
   private final GeoSearchService geoSearchService;
   private final EntityReader<Vehicle> vehicleReader;
   private final QueryParameterValidator validationService;
+  private final boolean defaultIncludeVehiclesAtNonVirtualStations;
 
   public VehicleQueryController(
     GeoSearchService geoSearchService,
     EntityReader<Vehicle> vehicleReader,
-    QueryParameterValidator validationService
+    QueryParameterValidator validationService,
+    @Value(
+      "${org.entur.lamassu.graphql.default-include-vehicles-at-non-virtual-stations:false}"
+    ) boolean defaultIncludeVehiclesAtNonVirtualStations
   ) {
     this.geoSearchService = geoSearchService;
     this.vehicleReader = vehicleReader;
     this.validationService = validationService;
+    this.defaultIncludeVehiclesAtNonVirtualStations =
+      defaultIncludeVehiclesAtNonVirtualStations;
   }
 
   @QueryMapping
@@ -55,7 +62,8 @@ public class VehicleQueryController {
     @Argument List<FormFactor> formFactors,
     @Argument List<PropulsionType> propulsionTypes,
     @Argument Boolean includeReserved,
-    @Argument Boolean includeDisabled
+    @Argument Boolean includeDisabled,
+    @Argument Boolean includeVehiclesAtNonVirtualStations
   ) {
     if (ids != null && !ids.isEmpty()) {
       return vehicleReader.getAll(new HashSet<>(ids));
@@ -73,7 +81,10 @@ public class VehicleQueryController {
       formFactors,
       propulsionTypes,
       includeReserved,
-      includeDisabled
+      includeDisabled,
+      includeVehiclesAtNonVirtualStations != null
+        ? includeVehiclesAtNonVirtualStations
+        : defaultIncludeVehiclesAtNonVirtualStations
     );
 
     Collection<Vehicle> vehicles;

--- a/src/main/java/org/entur/lamassu/graphql/subscription/VehicleSubscriptionController.java
+++ b/src/main/java/org/entur/lamassu/graphql/subscription/VehicleSubscriptionController.java
@@ -1,17 +1,20 @@
 package org.entur.lamassu.graphql.subscription;
 
 import java.util.List;
+import org.entur.lamassu.cache.EntityCache;
 import org.entur.lamassu.graphql.subscription.filter.VehicleUpdateFilter;
 import org.entur.lamassu.graphql.subscription.handler.VehicleSubscriptionHandler;
 import org.entur.lamassu.graphql.subscription.model.VehicleUpdate;
 import org.entur.lamassu.graphql.validation.QueryParameterValidator;
 import org.entur.lamassu.model.entities.FormFactor;
 import org.entur.lamassu.model.entities.PropulsionType;
+import org.entur.lamassu.model.entities.Station;
 import org.entur.lamassu.service.BoundingBoxQueryParameters;
 import org.entur.lamassu.service.FeedProviderService;
 import org.entur.lamassu.service.RangeQueryParameters;
 import org.entur.lamassu.service.VehicleFilterParameters;
 import org.reactivestreams.Publisher;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.graphql.data.method.annotation.Argument;
 import org.springframework.graphql.data.method.annotation.SubscriptionMapping;
 import org.springframework.stereotype.Controller;
@@ -26,15 +29,24 @@ public class VehicleSubscriptionController {
   private final VehicleSubscriptionHandler vehicleSubscriptionHandler;
   private final QueryParameterValidator validationService;
   private final FeedProviderService feedProviderService;
+  private final EntityCache<Station> stationCache;
+  private final boolean defaultIncludeVehiclesAtNonVirtualStations;
 
   public VehicleSubscriptionController(
     VehicleSubscriptionHandler vehicleSubscriptionHandler,
     QueryParameterValidator validationService,
-    FeedProviderService feedProviderService
+    FeedProviderService feedProviderService,
+    EntityCache<Station> stationCache,
+    @Value(
+      "${org.entur.lamassu.graphql.default-include-vehicles-at-non-virtual-stations:false}"
+    ) boolean defaultIncludeVehiclesAtNonVirtualStations
   ) {
     this.vehicleSubscriptionHandler = vehicleSubscriptionHandler;
     this.validationService = validationService;
     this.feedProviderService = feedProviderService;
+    this.stationCache = stationCache;
+    this.defaultIncludeVehiclesAtNonVirtualStations =
+      defaultIncludeVehiclesAtNonVirtualStations;
   }
 
   /**
@@ -72,7 +84,8 @@ public class VehicleSubscriptionController {
     @Argument List<FormFactor> formFactors,
     @Argument List<PropulsionType> propulsionTypes,
     @Argument Boolean includeReserved,
-    @Argument Boolean includeDisabled
+    @Argument Boolean includeDisabled,
+    @Argument Boolean includeVehiclesAtNonVirtualStations
   ) {
     // Validate parameters
     validationService.validateCodespaces(codespaces);
@@ -96,7 +109,10 @@ public class VehicleSubscriptionController {
       formFactors,
       propulsionTypes,
       includeReserved != null && includeReserved,
-      includeDisabled != null && includeDisabled
+      includeDisabled != null && includeDisabled,
+      includeVehiclesAtNonVirtualStations != null
+        ? includeVehiclesAtNonVirtualStations
+        : defaultIncludeVehiclesAtNonVirtualStations
     );
 
     // Create subscription handler
@@ -114,7 +130,8 @@ public class VehicleSubscriptionController {
           filterParams,
           queryParams,
           systemId ->
-            feedProviderService.getFeedProviderBySystemId(systemId).getCodespace()
+            feedProviderService.getFeedProviderBySystemId(systemId).getCodespace(),
+          this::isNonVirtualStation
         );
     } else {
       var queryParams = new BoundingBoxQueryParameters(
@@ -128,11 +145,20 @@ public class VehicleSubscriptionController {
           filterParams,
           queryParams,
           systemId ->
-            feedProviderService.getFeedProviderBySystemId(systemId).getCodespace()
+            feedProviderService.getFeedProviderBySystemId(systemId).getCodespace(),
+          this::isNonVirtualStation
         );
     }
 
     // Return publisher and ensure listener is removed when subscription ends
     return vehicleSubscriptionHandler.getPublisher(filter);
+  }
+
+  private boolean isNonVirtualStation(String stationId) {
+    var station = stationCache.get(stationId);
+    if (station == null) {
+      return false;
+    }
+    return !Boolean.TRUE.equals(station.getVirtualStation());
   }
 }

--- a/src/main/java/org/entur/lamassu/graphql/subscription/filter/VehicleUpdateFilter.java
+++ b/src/main/java/org/entur/lamassu/graphql/subscription/filter/VehicleUpdateFilter.java
@@ -19,6 +19,7 @@
 package org.entur.lamassu.graphql.subscription.filter;
 
 import java.util.List;
+import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
 import org.entur.lamassu.graphql.subscription.model.VehicleUpdate;
 import org.entur.lamassu.model.entities.FormFactor;
@@ -34,23 +35,28 @@ public class VehicleUpdateFilter
   implements EntityUpdateFilter<VehicleUpdate> {
 
   private final VehicleFilterParameters filterParameters;
+  private final Predicate<String> nonVirtualStationPredicate;
 
   public VehicleUpdateFilter(
     VehicleFilterParameters filterParameters,
     RangeQueryParameters rangeQueryParameters,
-    UnaryOperator<String> codespaceResolver
+    UnaryOperator<String> codespaceResolver,
+    Predicate<String> nonVirtualStationPredicate
   ) {
     super(filterParameters, rangeQueryParameters, codespaceResolver);
     this.filterParameters = filterParameters;
+    this.nonVirtualStationPredicate = nonVirtualStationPredicate;
   }
 
   public VehicleUpdateFilter(
     VehicleFilterParameters filterParameters,
     BoundingBoxQueryParameters boundingBoxParameters,
-    UnaryOperator<String> codespaceResolver
+    UnaryOperator<String> codespaceResolver,
+    Predicate<String> nonVirtualStationPredicate
   ) {
     super(filterParameters, boundingBoxParameters, codespaceResolver);
     this.filterParameters = filterParameters;
+    this.nonVirtualStationPredicate = nonVirtualStationPredicate;
   }
 
   @Override
@@ -127,10 +133,24 @@ public class VehicleUpdateFilter
     }
 
     // Filter by disabled status
-    return (
-      filterParameters.getIncludeDisabled() ||
-      vehicle.getDisabled() == null ||
-      !Boolean.TRUE.equals(vehicle.getDisabled())
-    );
+    if (
+      !filterParameters.getIncludeDisabled() &&
+      vehicle.getDisabled() != null &&
+      Boolean.TRUE.equals(vehicle.getDisabled())
+    ) {
+      return false;
+    }
+
+    // Filter by non-virtual station assignment
+    if (
+      !filterParameters.getIncludeVehiclesAtNonVirtualStations() &&
+      vehicle.getStationId() != null &&
+      nonVirtualStationPredicate != null &&
+      nonVirtualStationPredicate.test(vehicle.getStationId())
+    ) {
+      return false;
+    }
+
+    return true;
   }
 }

--- a/src/main/java/org/entur/lamassu/service/SpatialIndexIdGeneratorService.java
+++ b/src/main/java/org/entur/lamassu/service/SpatialIndexIdGeneratorService.java
@@ -17,10 +17,15 @@ import org.springframework.stereotype.Service;
 public class SpatialIndexIdGeneratorService {
 
   private final EntityCache<VehicleType> vehicleTypeCache;
+  private final EntityCache<Station> stationCache;
 
   @Autowired
-  public SpatialIndexIdGeneratorService(EntityCache<VehicleType> vehicleTypeCache) {
+  public SpatialIndexIdGeneratorService(
+    EntityCache<VehicleType> vehicleTypeCache,
+    EntityCache<Station> stationCache
+  ) {
     this.vehicleTypeCache = vehicleTypeCache;
+    this.stationCache = stationCache;
   }
 
   public VehicleSpatialIndexId createVehicleIndexId(
@@ -43,7 +48,19 @@ public class SpatialIndexIdGeneratorService {
     id.setPropulsionType(vehicleType.getPropulsionType());
     id.setReserved(vehicle.getReserved());
     id.setDisabled(vehicle.getDisabled());
+    id.setAtNonVirtualStation(isAtNonVirtualStation(vehicle));
     return id;
+  }
+
+  private boolean isAtNonVirtualStation(Vehicle vehicle) {
+    if (vehicle.getStationId() == null) {
+      return false;
+    }
+    var station = stationCache.get(vehicle.getStationId());
+    if (station == null) {
+      return false;
+    }
+    return !Boolean.TRUE.equals(station.getVirtualStation());
   }
 
   public StationSpatialIndexId createStationIndexId(

--- a/src/main/java/org/entur/lamassu/service/VehicleFilterParameters.java
+++ b/src/main/java/org/entur/lamassu/service/VehicleFilterParameters.java
@@ -10,6 +10,7 @@ public class VehicleFilterParameters extends FilterParameters {
   private List<PropulsionType> propulsionTypes;
   private boolean includeReserved;
   private boolean includeDisabled;
+  private boolean includeVehiclesAtNonVirtualStations;
 
   public VehicleFilterParameters(
     List<String> codespaces,
@@ -19,13 +20,15 @@ public class VehicleFilterParameters extends FilterParameters {
     List<FormFactor> formFactors,
     List<PropulsionType> propulsionTypes,
     boolean includeReserved,
-    boolean includeDisabled
+    boolean includeDisabled,
+    boolean includeVehiclesAtNonVirtualStations
   ) {
     super(codespaces, systems, operators, count);
     this.formFactors = formFactors;
     this.propulsionTypes = propulsionTypes;
     this.includeReserved = includeReserved;
     this.includeDisabled = includeDisabled;
+    this.includeVehiclesAtNonVirtualStations = includeVehiclesAtNonVirtualStations;
   }
 
   public List<FormFactor> getFormFactors() {
@@ -58,5 +61,15 @@ public class VehicleFilterParameters extends FilterParameters {
 
   public void setIncludeDisabled(boolean includeDisabled) {
     this.includeDisabled = includeDisabled;
+  }
+
+  public boolean getIncludeVehiclesAtNonVirtualStations() {
+    return includeVehiclesAtNonVirtualStations;
+  }
+
+  public void setIncludeVehiclesAtNonVirtualStations(
+    boolean includeVehiclesAtNonVirtualStations
+  ) {
+    this.includeVehiclesAtNonVirtualStations = includeVehiclesAtNonVirtualStations;
   }
 }

--- a/src/main/java/org/entur/lamassu/util/SpatialIndexIdFilter.java
+++ b/src/main/java/org/entur/lamassu/util/SpatialIndexIdFilter.java
@@ -56,6 +56,13 @@ public class SpatialIndexIdFilter {
       return false;
     }
 
+    if (
+      !filters.getIncludeVehiclesAtNonVirtualStations() &&
+      parsedId.getAtNonVirtualStation()
+    ) {
+      return false;
+    }
+
     return true;
   }
 

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -14,6 +14,7 @@ type Subscription {
         propulsionTypes: [PropulsionType]
         includeReserved: Boolean = false
         includeDisabled: Boolean = false
+        includeVehiclesAtNonVirtualStations: Boolean
     ): [VehicleUpdate] @deprecated(reason: "Experimental feature - API is subject to change")
 
     stations(
@@ -105,6 +106,9 @@ type Query {
 
         "Include disabled vehicles in result"
         includeDisabled: Boolean = false
+
+        "Include vehicles assigned to non-virtual stations in result"
+        includeVehiclesAtNonVirtualStations: Boolean
     ): [Vehicle]
 
     station(id: String!): Station

--- a/src/test/java/org/entur/lamassu/graphql/subscription/VehicleSubscriptionControllerTest.java
+++ b/src/test/java/org/entur/lamassu/graphql/subscription/VehicleSubscriptionControllerTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import org.entur.lamassu.cache.EntityCache;
 import org.entur.lamassu.graphql.subscription.filter.VehicleUpdateFilter;
 import org.entur.lamassu.graphql.subscription.handler.VehicleSubscriptionHandler;
 import org.entur.lamassu.graphql.subscription.model.UpdateType;
@@ -16,6 +17,7 @@ import org.entur.lamassu.graphql.subscription.model.VehicleUpdate;
 import org.entur.lamassu.graphql.validation.QueryParameterValidator;
 import org.entur.lamassu.model.entities.FormFactor;
 import org.entur.lamassu.model.entities.PropulsionType;
+import org.entur.lamassu.model.entities.Station;
 import org.entur.lamassu.model.entities.Vehicle;
 import org.entur.lamassu.model.entities.VehicleType;
 import org.entur.lamassu.model.provider.FeedProvider;
@@ -25,7 +27,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.reactivestreams.Publisher;
@@ -48,7 +49,9 @@ class VehicleSubscriptionControllerTest {
   @Mock
   private FeedProviderService feedProviderService;
 
-  @InjectMocks
+  @Mock
+  private EntityCache<Station> stationCache;
+
   private VehicleSubscriptionController controller;
 
   private static final String TEST_SYSTEM_ID = "test-system";
@@ -56,6 +59,14 @@ class VehicleSubscriptionControllerTest {
 
   @BeforeEach
   void setUp() {
+    controller =
+      new VehicleSubscriptionController(
+        subscriptionHandler,
+        validationService,
+        feedProviderService,
+        stationCache,
+        false
+      );
     // Setup common mocks with lenient to avoid UnnecessaryStubbingException
     FeedProvider feedProvider = new FeedProvider();
     feedProvider.setSystemId(TEST_SYSTEM_ID);
@@ -98,6 +109,7 @@ class VehicleSubscriptionControllerTest {
       11.0,
       List.of(TEST_CODESPACE),
       List.of(TEST_SYSTEM_ID),
+      null,
       null,
       null,
       null,
@@ -155,6 +167,7 @@ class VehicleSubscriptionControllerTest {
       59.5,
       10.5,
       1000,
+      null,
       null,
       null,
       null,
@@ -224,6 +237,7 @@ class VehicleSubscriptionControllerTest {
       List.of(FormFactor.BICYCLE),
       List.of(PropulsionType.ELECTRIC),
       null,
+      null,
       null
     );
 
@@ -287,7 +301,8 @@ class VehicleSubscriptionControllerTest {
       null,
       null,
       true, // includeReserved
-      false // includeDisabled
+      false, // includeDisabled
+      null // includeVehiclesAtNonVirtualStations
     );
 
     // Verify the result
@@ -342,6 +357,7 @@ class VehicleSubscriptionControllerTest {
       null,
       null,
       List.of("test-operator"),
+      null,
       null,
       null,
       null,

--- a/src/test/java/org/entur/lamassu/graphql/subscription/filter/VehicleUpdateFilterTest.java
+++ b/src/test/java/org/entur/lamassu/graphql/subscription/filter/VehicleUpdateFilterTest.java
@@ -58,6 +58,7 @@ class VehicleUpdateFilterTest {
       null,
       null,
       false,
+      false,
       false
     );
 
@@ -71,7 +72,8 @@ class VehicleUpdateFilterTest {
     VehicleUpdateFilter filter = new VehicleUpdateFilter(
       filterParams,
       bbox,
-      CODESPACE_RESOLVER
+      CODESPACE_RESOLVER,
+      null
     );
 
     // Create test updates inside and outside the bounding box
@@ -100,6 +102,7 @@ class VehicleUpdateFilterTest {
       null,
       null,
       false,
+      false,
       false
     );
 
@@ -109,7 +112,8 @@ class VehicleUpdateFilterTest {
     VehicleUpdateFilter filter = new VehicleUpdateFilter(
       filterParams,
       rangeParams,
-      CODESPACE_RESOLVER
+      CODESPACE_RESOLVER,
+      null
     );
 
     // Create test updates inside and outside the range
@@ -135,6 +139,7 @@ class VehicleUpdateFilterTest {
       null,
       null,
       false,
+      false,
       false
     );
 
@@ -156,7 +161,8 @@ class VehicleUpdateFilterTest {
     VehicleUpdateFilter filter = new VehicleUpdateFilter(
       filterParams,
       bbox,
-      codespaceResolver
+      codespaceResolver,
+      null
     );
 
     // Create test updates with matching and non-matching codespaces
@@ -192,6 +198,7 @@ class VehicleUpdateFilterTest {
       List.of(FormFactor.SCOOTER),
       null,
       false,
+      false,
       false
     );
 
@@ -205,7 +212,8 @@ class VehicleUpdateFilterTest {
     VehicleUpdateFilter filter = new VehicleUpdateFilter(
       filterParams,
       bbox,
-      CODESPACE_RESOLVER
+      CODESPACE_RESOLVER,
+      null
     );
 
     // Create test updates with matching and non-matching form factors
@@ -239,6 +247,7 @@ class VehicleUpdateFilterTest {
       null,
       List.of(PropulsionType.ELECTRIC),
       false,
+      false,
       false
     );
 
@@ -252,7 +261,8 @@ class VehicleUpdateFilterTest {
     VehicleUpdateFilter filter = new VehicleUpdateFilter(
       filterParams,
       bbox,
-      CODESPACE_RESOLVER
+      CODESPACE_RESOLVER,
+      null
     );
 
     // Create test updates with matching and non-matching propulsion types
@@ -289,7 +299,8 @@ class VehicleUpdateFilterTest {
       null,
       null,
       false,
-      true
+      true,
+      false
     );
 
     BoundingBoxQueryParameters bbox = new BoundingBoxQueryParameters(
@@ -302,7 +313,8 @@ class VehicleUpdateFilterTest {
     VehicleUpdateFilter filter = new VehicleUpdateFilter(
       filterParams,
       bbox,
-      CODESPACE_RESOLVER
+      CODESPACE_RESOLVER,
+      null
     );
 
     // Create test updates with reserved and non-reserved vehicles
@@ -333,13 +345,15 @@ class VehicleUpdateFilterTest {
       null,
       null,
       true,
-      true
+      true,
+      false
     );
 
     VehicleUpdateFilter includeReservedFilter = new VehicleUpdateFilter(
       includeReservedParams,
       bbox,
-      CODESPACE_RESOLVER
+      CODESPACE_RESOLVER,
+      null
     );
 
     assertTrue(
@@ -359,6 +373,7 @@ class VehicleUpdateFilterTest {
       null,
       null,
       true,
+      false,
       false
     );
 
@@ -372,7 +387,8 @@ class VehicleUpdateFilterTest {
     VehicleUpdateFilter filter = new VehicleUpdateFilter(
       filterParams,
       bbox,
-      CODESPACE_RESOLVER
+      CODESPACE_RESOLVER,
+      null
     );
 
     // Create test updates with disabled and enabled vehicles
@@ -403,13 +419,15 @@ class VehicleUpdateFilterTest {
       null,
       null,
       true,
-      true
+      true,
+      false
     );
 
     VehicleUpdateFilter includeDisabledFilter = new VehicleUpdateFilter(
       includeDisabledParams,
       bbox,
-      CODESPACE_RESOLVER
+      CODESPACE_RESOLVER,
+      null
     );
 
     assertTrue(
@@ -429,7 +447,8 @@ class VehicleUpdateFilterTest {
       null,
       null,
       true,
-      true
+      true,
+      false
     );
 
     BoundingBoxQueryParameters bbox = new BoundingBoxQueryParameters(
@@ -442,7 +461,8 @@ class VehicleUpdateFilterTest {
     VehicleUpdateFilter filter = new VehicleUpdateFilter(
       filterParams,
       bbox,
-      CODESPACE_RESOLVER
+      CODESPACE_RESOLVER,
+      null
     );
 
     // Create test updates with matching and non-matching system IDs
@@ -475,7 +495,8 @@ class VehicleUpdateFilterTest {
       null,
       null,
       true,
-      true
+      true,
+      false
     );
 
     BoundingBoxQueryParameters bbox = new BoundingBoxQueryParameters(
@@ -488,7 +509,8 @@ class VehicleUpdateFilterTest {
     VehicleUpdateFilter filter = new VehicleUpdateFilter(
       filterParams,
       bbox,
-      CODESPACE_RESOLVER
+      CODESPACE_RESOLVER,
+      null
     );
 
     // Create test updates with matching and non-matching operator IDs
@@ -526,7 +548,8 @@ class VehicleUpdateFilterTest {
       List.of(FormFactor.BICYCLE),
       null,
       true,
-      true
+      true,
+      false
     );
 
     BoundingBoxQueryParameters bbox = new BoundingBoxQueryParameters(
@@ -539,7 +562,8 @@ class VehicleUpdateFilterTest {
     VehicleUpdateFilter filter = new VehicleUpdateFilter(
       filterParams,
       bbox,
-      CODESPACE_RESOLVER
+      CODESPACE_RESOLVER,
+      null
     );
 
     // Create a vehicle update with null vehicle type

--- a/src/test/java/org/entur/lamassu/graphql/subscription/handler/VehicleSubscriptionHandlerTest.java
+++ b/src/test/java/org/entur/lamassu/graphql/subscription/handler/VehicleSubscriptionHandlerTest.java
@@ -93,6 +93,7 @@ class VehicleSubscriptionHandlerTest {
       null,
       null,
       false,
+      false,
       false
     );
 
@@ -150,6 +151,7 @@ class VehicleSubscriptionHandlerTest {
       null,
       null,
       null,
+      false,
       false,
       false
     );
@@ -212,6 +214,7 @@ class VehicleSubscriptionHandlerTest {
       null,
       null,
       null,
+      false,
       false,
       false
     );
@@ -282,6 +285,7 @@ class VehicleSubscriptionHandlerTest {
       null,
       null,
       null,
+      false,
       false,
       false
     );
@@ -393,6 +397,7 @@ class VehicleSubscriptionHandlerTest {
       null,
       null,
       false,
+      false,
       false
     );
 
@@ -454,6 +459,7 @@ class VehicleSubscriptionHandlerTest {
       null,
       null,
       null,
+      false,
       false,
       false
     );

--- a/src/test/java/org/entur/lamassu/leader/entityupdater/StationsUpdaterTest.java
+++ b/src/test/java/org/entur/lamassu/leader/entityupdater/StationsUpdaterTest.java
@@ -68,7 +68,8 @@ class StationsUpdaterTest {
     RentalUrisMapper rentalUrisMapper = new RentalUrisMapper();
     stationMapper = new StationMapper(translationMapper, rentalUrisMapper);
 
-    spatialIndexIdGeneratorService = new SpatialIndexIdGeneratorService(vehicleTypeCache);
+    spatialIndexIdGeneratorService =
+      new SpatialIndexIdGeneratorService(vehicleTypeCache, stationCache);
     stationsUpdater =
       new StationsUpdater(
         stationCache,

--- a/src/test/java/org/entur/lamassu/leader/entityupdater/VehiclesUpdaterTest.java
+++ b/src/test/java/org/entur/lamassu/leader/entityupdater/VehiclesUpdaterTest.java
@@ -72,7 +72,8 @@ class VehiclesUpdaterTest {
     vehicleMapper = new VehicleMapper(rentalUrisMapper);
 
     // Initialize real services
-    spatialIndexIdGeneratorService = new SpatialIndexIdGeneratorService(vehicleTypeCache);
+    spatialIndexIdGeneratorService =
+      new SpatialIndexIdGeneratorService(vehicleTypeCache, stationCache);
 
     vehiclesUpdater =
       new VehiclesUpdater(

--- a/src/test/java/org/entur/lamassu/util/SpatialIndexIdFilterTest.java
+++ b/src/test/java/org/entur/lamassu/util/SpatialIndexIdFilterTest.java
@@ -121,6 +121,29 @@ public class SpatialIndexIdFilterTest {
   }
 
   @Test
+  public void testIncludeVehiclesAtNonVirtualStationsFilter() {
+    var testId = aVehicleId();
+    testId.setAtNonVirtualStation(true);
+    var params = aVehicleFilterParams();
+
+    params.setIncludeVehiclesAtNonVirtualStations(true);
+    Assert.assertTrue(SpatialIndexIdFilter.filterVehicle(testId, params));
+
+    params.setIncludeVehiclesAtNonVirtualStations(false);
+    Assert.assertFalse(SpatialIndexIdFilter.filterVehicle(testId, params));
+  }
+
+  @Test
+  public void testVehicleNotAtNonVirtualStationPassesFilter() {
+    var testId = aVehicleId();
+    testId.setAtNonVirtualStation(false);
+    var params = aVehicleFilterParams();
+
+    params.setIncludeVehiclesAtNonVirtualStations(false);
+    Assert.assertTrue(SpatialIndexIdFilter.filterVehicle(testId, params));
+  }
+
+  @Test
   public void testVehicleTypesAvailableFilter() {
     var testId = aStationId();
     var params = new StationFilterParameters(
@@ -208,7 +231,17 @@ public class SpatialIndexIdFilterTest {
   }
 
   private VehicleFilterParameters aVehicleFilterParams() {
-    return new VehicleFilterParameters(null, null, null, null, null, null, false, false);
+    return new VehicleFilterParameters(
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      false,
+      false,
+      false
+    );
   }
 
   private StationFilterParameters aStationFilterParams() {

--- a/src/test/java/org/entur/lamassu/util/TestSpatialIndexBuilder.java
+++ b/src/test/java/org/entur/lamassu/util/TestSpatialIndexBuilder.java
@@ -28,6 +28,7 @@ public class TestSpatialIndexBuilder {
     id.setPropulsionType(vehicle.getVehicleType().getPropulsionType());
     id.setReserved(vehicle.getReserved());
     id.setDisabled(vehicle.getDisabled());
+    id.setAtNonVirtualStation(false);
     return id;
   }
 


### PR DESCRIPTION
When the ingestion property include-vehicles-assigned-to-non-virtual-stations is enabled, vehicles at non-virtual stations are no longer filtered during ingestion. This adds a corresponding opt-in filter to the GraphQL API so clients can still exclude those vehicles by default.

The new includeVehiclesAtNonVirtualStations argument is available on both the vehicles query and subscription. Its default value is configurable via org.entur.lamassu.graphql.default-include-vehicles-at-non-virtual-stations (defaults to false).

