### PR TITLE
Fix: handle mapping geofencing zones without rules gracefully

### DIFF
--- a/src/main/java/org/entur/lamassu/mapper/entitymapper/GeofencingZonesMapper.java
+++ b/src/main/java/org/entur/lamassu/mapper/entitymapper/GeofencingZonesMapper.java
@@ -91,7 +91,7 @@ public class GeofencingZonesMapper {
     return features.stream().map(feature -> mapFeature(feature, language)).toList();
   }
 
-  private org.entur.lamassu.model.entities.GeofencingZones.Feature mapFeature(
+  protected org.entur.lamassu.model.entities.GeofencingZones.Feature mapFeature(
     GBFSFeature feature,
     String language
   ) {

--- a/src/main/java/org/entur/lamassu/mapper/entitymapper/GeofencingZonesMapper.java
+++ b/src/main/java/org/entur/lamassu/mapper/entitymapper/GeofencingZonesMapper.java
@@ -122,7 +122,9 @@ public class GeofencingZonesMapper {
     mapped.setEnd(
       properties.getEnd() != null ? properties.getEnd().getTime() / 1000 : null
     );
-    mapped.setRules(mapRules(properties.getRules()));
+    mapped.setRules(
+      properties.getRules() != null ? mapRules(properties.getRules()) : null
+    );
     return mapped;
   }
 

--- a/src/main/java/org/entur/lamassu/mapper/feedmapper/v2/GeofencingZonesFeedMapper.java
+++ b/src/main/java/org/entur/lamassu/mapper/feedmapper/v2/GeofencingZonesFeedMapper.java
@@ -97,11 +97,13 @@ public class GeofencingZonesFeedMapper extends AbstractFeedMapper<GBFSGeofencing
     mapped.setStart(properties.getStart());
     mapped.setEnd(properties.getEnd());
     mapped.setRules(
-      properties
-        .getRules()
-        .stream()
-        .map(rule -> mapRule(rule, feedProvider))
-        .collect(Collectors.toList())
+      properties.getRules() != null
+        ? properties
+          .getRules()
+          .stream()
+          .map(rule -> mapRule(rule, feedProvider))
+          .collect(Collectors.toList())
+        : null
     );
     return mapped;
   }

--- a/src/main/java/org/entur/lamassu/mapper/feedmapper/v3/V3GeofencingZonesFeedMapper.java
+++ b/src/main/java/org/entur/lamassu/mapper/feedmapper/v3/V3GeofencingZonesFeedMapper.java
@@ -105,11 +105,13 @@ public class V3GeofencingZonesFeedMapper extends AbstractFeedMapper<GBFSGeofenci
     mapped.setStart(properties.getStart());
     mapped.setEnd(properties.getEnd());
     mapped.setRules(
-      properties
-        .getRules()
-        .stream()
-        .map(rule -> mapRule(rule, feedProvider))
-        .collect(Collectors.toList())
+      properties.getRules() != null
+        ? properties
+          .getRules()
+          .stream()
+          .map(rule -> mapRule(rule, feedProvider))
+          .collect(Collectors.toList())
+        : null
     );
     return mapped;
   }

--- a/src/test/java/org/entur/lamassu/mapper/entitymapper/GeofencingZonesMapperTest.java
+++ b/src/test/java/org/entur/lamassu/mapper/entitymapper/GeofencingZonesMapperTest.java
@@ -1,0 +1,23 @@
+package org.entur.lamassu.mapper.entitymapper;
+
+import java.util.Collections;
+import org.entur.lamassu.model.entities.GeofencingZones;
+import org.entur.lamassu.model.provider.FeedProvider;
+import org.geojson.MultiPolygon;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mobilitydata.gbfs.v3_0.geofencing_zones.GBFSFeature;
+import org.mobilitydata.gbfs.v3_0.geofencing_zones.GBFSProperties;
+
+public class GeofencingZonesMapperTest {
+
+  @Test
+  void testMapFeedWhenGeofencingZoneHasNoRules() {
+    var mapper = new GeofencingZonesMapper();
+    var feature = new GBFSFeature();
+    feature.setProperties(new GBFSProperties());
+    feature.setGeometry(new MultiPolygon());
+    var mappedFeature = mapper.mapFeature(feature, "en");
+    Assertions.assertNull(mappedFeature.getProperties().getRules());
+  }
+}


### PR DESCRIPTION
### Summary

This PR handles geofencing zone properties without property `rule` by mapping to it to `null`. 

### Issue
Fixes #866

### Unit tests

- Added one unit test for GeofencingZonesMapper, not yet for v2/v3 GeofencingZonesFeedMappers
