### PR TITLE
fix: station missing from entity caches when station_information lags station_status

### DIFF
--- a/src/main/java/org/entur/lamassu/leader/entityupdater/EntityCachesUpdater.java
+++ b/src/main/java/org/entur/lamassu/leader/entityupdater/EntityCachesUpdater.java
@@ -27,11 +27,15 @@ import org.entur.lamassu.model.provider.FeedProvider;
 import org.mobilitydata.gbfs.v2_3.gbfs.GBFSFeedName;
 import org.mobilitydata.gbfs.v3_0.station_status.GBFSStation;
 import org.mobilitydata.gbfs.v3_0.vehicle_status.GBFSVehicle;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
 public class EntityCachesUpdater {
+
+  private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
   private final SystemUpdater systemUpdater;
   private final VehicleTypesUpdater vehicleTypesUpdater;
@@ -101,15 +105,26 @@ public class EntityCachesUpdater {
           useBase ? oldDelivery.stationStatus() : null,
           delivery.stationStatus()
         );
-      stationsUpdater.update(
+      var fullyApplied = stationsUpdater.update(
         feedProvider,
         stationStatusDelta,
         delivery.stationInformation()
       );
-      updateContinuityTracker.updateStationUpdateContinuity(
-        feedProvider.getSystemId(),
-        delivery
-      );
+      if (fullyApplied) {
+        updateContinuityTracker.updateStationUpdateContinuity(
+          feedProvider.getSystemId(),
+          delivery
+        );
+      } else {
+        // One or more stations could not be added to the entity cache. Since the
+        // delta for those stations will not occur again, clear continuity so the
+        // next update performs a full rebuild instead of permanently losing them.
+        logger.warn(
+          "Station update was not fully applied for system={}, clearing update continuity to force full rebuild on next update",
+          feedProvider.getSystemId()
+        );
+        updateContinuityTracker.clearStationUpdateContinuity(feedProvider.getSystemId());
+      }
     }
 
     if (canUpdateVehicles(delivery, feedProvider)) {

--- a/src/main/java/org/entur/lamassu/leader/entityupdater/StationsUpdater.java
+++ b/src/main/java/org/entur/lamassu/leader/entityupdater/StationsUpdater.java
@@ -58,6 +58,11 @@ public class StationsUpdater {
     final Set<StationSpatialIndexId> spatialIndexIdsToRemove = new HashSet<>();
     final Map<StationSpatialIndexId, Station> spatialIndexUpdateMap = new HashMap<>();
 
+    // Set to false when a delta could not be applied, leaving a station missing
+    // from the entity cache. Signals that delta continuity must be broken so the
+    // next update performs a full rebuild instead of permanently losing the station.
+    boolean fullyApplied = true;
+
     public UpdateContext(
       FeedProvider feedProvider,
       Map<String, org.mobilitydata.gbfs.v3_0.station_information.GBFSStation> stationInfo
@@ -90,7 +95,15 @@ public class StationsUpdater {
     this.spatialIndexService = spatialIndexService;
   }
 
-  public void update(
+  /**
+   * Applies a station status delta to the entity caches.
+   *
+   * @return true if the delta was fully applied, false if one or more stations
+   * could not be added to the entity cache (e.g. due to missing station
+   * information), in which case delta continuity should be broken to force a
+   * full rebuild on the next update
+   */
+  public boolean update(
     FeedProvider feedProvider,
     GBFSFileDelta<GBFSStation> delta,
     GBFSStationInformation stationInformationFeed
@@ -115,6 +128,8 @@ public class StationsUpdater {
     }
 
     updateCaches(context);
+
+    return context.fullyApplied;
   }
 
   private static @NotNull Map<String, org.mobilitydata.gbfs.v3_0.station_information.@NotNull GBFSStation> extractStationInfo(
@@ -191,10 +206,11 @@ public class StationsUpdater {
     var stationInformation = context.stationInfo.get(stationId);
     if (stationInformation == null) {
       logger.warn(
-        "Skipping station due to missing station information feed for provider={} stationId={}",
+        "Skipping station create due to missing station information feed for provider={} stationId={}",
         context.feedProvider,
         stationId
       );
+      context.fullyApplied = false;
       return;
     }
 
@@ -221,40 +237,44 @@ public class StationsUpdater {
     Station currentStation
   ) {
     var stationId = entityDelta.entityId();
+
+    if (currentStation == null) {
+      logger.warn(
+        "Station marked for update but not found in cache for provider={} stationId={}",
+        context.feedProvider,
+        stationId
+      );
+      context.fullyApplied = false;
+      return;
+    }
+
     var stationInformation = context.stationInfo.get(stationId);
     if (stationInformation == null) {
       logger.warn(
-        "Skipping station due to missing station information feed for provider={} stationId={}",
+        "Skipping station update due to missing station information feed for provider={} stationId={}",
         context.feedProvider,
         stationId
       );
       return;
     }
 
-    if (currentStation != null) {
-      context.spatialIndexIdsToRemove.add(
-        spatialIndexService.createStationIndexId(currentStation, context.feedProvider)
-      );
+    context.spatialIndexIdsToRemove.add(
+      spatialIndexService.createStationIndexId(currentStation, context.feedProvider)
+    );
 
-      Station mappedStation = stationMapper.mapStation(
-        stationInformation,
-        entityDelta.entity(),
-        context.feedProvider.getSystemId(),
-        context.feedProvider.getLanguage()
-      );
+    Station mappedStation = stationMapper.mapStation(
+      stationInformation,
+      entityDelta.entity(),
+      context.feedProvider.getSystemId(),
+      context.feedProvider.getLanguage()
+    );
 
-      context.addedAndUpdatedStations.put(mappedStation.getId(), mappedStation);
+    context.addedAndUpdatedStations.put(mappedStation.getId(), mappedStation);
 
-      context.spatialIndexUpdateMap.put(
-        spatialIndexService.createStationIndexId(mappedStation, context.feedProvider),
-        mappedStation
-      );
-    } else {
-      logger.debug(
-        "Station {} marked for update but not found in cache",
-        entityDelta.entityId()
-      );
-    }
+    context.spatialIndexUpdateMap.put(
+      spatialIndexService.createStationIndexId(mappedStation, context.feedProvider),
+      mappedStation
+    );
   }
 
   private void updateCaches(UpdateContext context) {

--- a/src/test/java/org/entur/lamassu/leader/entityupdater/EntityCachesUpdaterStationInformationLagTest.java
+++ b/src/test/java/org/entur/lamassu/leader/entityupdater/EntityCachesUpdaterStationInformationLagTest.java
@@ -1,0 +1,259 @@
+package org.entur.lamassu.leader.entityupdater;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.Date;
+import java.util.List;
+import org.entur.gbfs.loader.v3.GbfsV3Delivery;
+import org.entur.lamassu.cache.StationSpatialIndex;
+import org.entur.lamassu.leader.GbfsUpdateContinuityTracker;
+import org.entur.lamassu.mapper.entitymapper.RentalUrisMapper;
+import org.entur.lamassu.mapper.entitymapper.StationMapper;
+import org.entur.lamassu.mapper.entitymapper.TranslationMapper;
+import org.entur.lamassu.metrics.MetricsService;
+import org.entur.lamassu.model.entities.Station;
+import org.entur.lamassu.model.entities.VehicleType;
+import org.entur.lamassu.model.provider.FeedProvider;
+import org.entur.lamassu.service.SpatialIndexIdGeneratorService;
+import org.entur.lamassu.stubs.EntityCacheStub;
+import org.entur.lamassu.stubs.StubUpdateContinuityCache;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mobilitydata.gbfs.v3_0.station_information.GBFSName;
+import org.mobilitydata.gbfs.v3_0.station_information.GBFSStationInformation;
+import org.mobilitydata.gbfs.v3_0.station_status.GBFSData;
+import org.mobilitydata.gbfs.v3_0.station_status.GBFSStation;
+import org.mobilitydata.gbfs.v3_0.station_status.GBFSStationStatus;
+import org.mobilitydata.gbfs.v3_0.system_information.GBFSSystemInformation;
+import org.mobilitydata.gbfs.v3_0.system_pricing_plans.GBFSSystemPricingPlans;
+import org.mobilitydata.gbfs.v3_0.vehicle_types.GBFSVehicleTypes;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Reproduces a production issue where a station newly added by a provider was present
+ * in the GBFS feed endpoints but permanently missing from the entity cache / GraphQL
+ * API until the subscription was restarted.
+ *
+ * Scenario: the provider adds a station to station_status before it is visible in
+ * station_information (the two files are fetched on independent TTL schedules, and
+ * providers do not update files atomically). The station_status delta emits CREATE
+ * for the station exactly once, but StationsUpdater must drop it because station
+ * information is missing. Since delta continuity is otherwise intact, no CREATE is
+ * ever emitted again for that station.
+ *
+ * The fix: when a station delta cannot be fully applied, station update continuity
+ * is cleared, forcing a full rebuild on the next update, which picks up the station
+ * once its station information has become available.
+ */
+@ExtendWith(MockitoExtension.class)
+class EntityCachesUpdaterStationInformationLagTest {
+
+  private static final String SYSTEM_ID = "test-system";
+  private static final String EXISTING_STATION_ID = "station-1";
+  private static final String NEW_STATION_ID = "station-2";
+
+  @Mock
+  private SystemUpdater systemUpdater;
+
+  @Mock
+  private VehicleTypesUpdater vehicleTypesUpdater;
+
+  @Mock
+  private PricingPlansUpdater pricingPlansUpdater;
+
+  @Mock
+  private RegionsUpdater regionsUpdater;
+
+  @Mock
+  private VehiclesUpdater vehiclesUpdater;
+
+  @Mock
+  private GeofencingZonesUpdater geofencingZonesUpdater;
+
+  @Mock
+  private StationSpatialIndex spatialIndex;
+
+  @Mock
+  private MetricsService metricsService;
+
+  private final EntityCacheStub<Station> stationCache = new EntityCacheStub<>();
+  private final EntityCacheStub<VehicleType> vehicleTypeCache = new EntityCacheStub<>();
+
+  private EntityCachesUpdater entityCachesUpdater;
+  private FeedProvider feedProvider;
+
+  @BeforeEach
+  void setUp() {
+    var stationsUpdater = new StationsUpdater(
+      stationCache,
+      spatialIndex,
+      new StationMapper(new TranslationMapper(), new RentalUrisMapper()),
+      metricsService,
+      new SpatialIndexIdGeneratorService(vehicleTypeCache)
+    );
+
+    var continuityTracker = new GbfsUpdateContinuityTracker(
+      new StubUpdateContinuityCache(),
+      new StubUpdateContinuityCache()
+    );
+
+    entityCachesUpdater =
+      new EntityCachesUpdater(
+        systemUpdater,
+        vehicleTypesUpdater,
+        pricingPlansUpdater,
+        regionsUpdater,
+        vehiclesUpdater,
+        stationsUpdater,
+        geofencingZonesUpdater,
+        continuityTracker
+      );
+
+    feedProvider = new FeedProvider();
+    feedProvider.setSystemId(SYSTEM_ID);
+    feedProvider.setCodespace("test");
+    feedProvider.setOperatorId("test-operator");
+    feedProvider.setLanguage("en");
+  }
+
+  @Test
+  void newStationShouldEventuallyAppearWhenStationInformationLagsStationStatus() {
+    // Poll 0: steady state with one station
+    var status0 = statusFeed(1000L, status(EXISTING_STATION_ID, 5));
+    var infoWithoutNewStation = infoFeed(info(EXISTING_STATION_ID));
+
+    entityCachesUpdater.updateEntityCaches(
+      feedProvider,
+      delivery(status0, infoWithoutNewStation),
+      oldDelivery(null)
+    );
+    assertNotNull(stationCache.get(EXISTING_STATION_ID));
+
+    // Poll 1: the new station appears in station_status, but station_information
+    // still lags behind
+    var status1 = statusFeed(
+      2000L,
+      status(EXISTING_STATION_ID, 5),
+      status(NEW_STATION_ID, 3)
+    );
+
+    entityCachesUpdater.updateEntityCaches(
+      feedProvider,
+      delivery(status1, infoWithoutNewStation),
+      oldDelivery(status0)
+    );
+    // The CREATE delta is dropped because station information is missing
+    assertNull(stationCache.get(NEW_STATION_ID));
+
+    // Poll 2: station_information has caught up, station_status is unchanged, so
+    // no CREATE delta is emitted for the new station anymore
+    var status2 = statusFeed(
+      3000L,
+      status(EXISTING_STATION_ID, 5),
+      status(NEW_STATION_ID, 3)
+    );
+    var infoWithNewStation = infoFeed(info(EXISTING_STATION_ID), info(NEW_STATION_ID));
+
+    entityCachesUpdater.updateEntityCaches(
+      feedProvider,
+      delivery(status2, infoWithNewStation),
+      oldDelivery(status1)
+    );
+
+    // The incomplete update in poll 1 must have broken update continuity, forcing
+    // a full rebuild in poll 2 that picks up the new station
+    assertNotNull(stationCache.get(NEW_STATION_ID));
+    assertNotNull(stationCache.get(EXISTING_STATION_ID));
+  }
+
+  private GbfsV3Delivery delivery(
+    GBFSStationStatus stationStatus,
+    GBFSStationInformation stationInformation
+  ) {
+    var systemInformation = new GBFSSystemInformation();
+    systemInformation.setData(
+      new org.mobilitydata.gbfs.v3_0.system_information.GBFSData()
+    );
+    var vehicleTypes = new GBFSVehicleTypes();
+    vehicleTypes.setData(new org.mobilitydata.gbfs.v3_0.vehicle_types.GBFSData());
+    var pricingPlans = new GBFSSystemPricingPlans();
+    pricingPlans.setData(new org.mobilitydata.gbfs.v3_0.system_pricing_plans.GBFSData());
+
+    return new GbfsV3Delivery(
+      null,
+      null,
+      systemInformation,
+      vehicleTypes,
+      stationInformation,
+      stationStatus,
+      null,
+      null,
+      pricingPlans,
+      null,
+      null,
+      null
+    );
+  }
+
+  private GbfsV3Delivery oldDelivery(GBFSStationStatus stationStatus) {
+    return new GbfsV3Delivery(
+      null,
+      null,
+      null,
+      null,
+      null,
+      stationStatus,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null
+    );
+  }
+
+  private GBFSStationStatus statusFeed(long lastUpdated, GBFSStation... stations) {
+    var feed = new GBFSStationStatus();
+    feed.setLastUpdated(new Date(lastUpdated));
+    var data = new GBFSData();
+    data.setStations(List.of(stations));
+    feed.setData(data);
+    return feed;
+  }
+
+  private GBFSStation status(String stationId, int numVehiclesAvailable) {
+    var status = new GBFSStation();
+    status.setStationId(stationId);
+    status.setNumVehiclesAvailable(numVehiclesAvailable);
+    status.setNumDocksAvailable(10);
+    status.setIsInstalled(true);
+    status.setIsRenting(true);
+    status.setIsReturning(true);
+    status.setLastReported(new Date(0));
+    return status;
+  }
+
+  private GBFSStationInformation infoFeed(
+    org.mobilitydata.gbfs.v3_0.station_information.GBFSStation... stations
+  ) {
+    var feed = new GBFSStationInformation();
+    var data = new org.mobilitydata.gbfs.v3_0.station_information.GBFSData();
+    data.setStations(List.of(stations));
+    feed.setData(data);
+    return feed;
+  }
+
+  private org.mobilitydata.gbfs.v3_0.station_information.GBFSStation info(
+    String stationId
+  ) {
+    var info = new org.mobilitydata.gbfs.v3_0.station_information.GBFSStation();
+    info.setStationId(stationId);
+    info.setName(List.of(new GBFSName().withLanguage("en").withText(stationId)));
+    info.setLat(59.9);
+    info.setLon(10.7);
+    return info;
+  }
+}

--- a/src/test/java/org/entur/lamassu/leader/entityupdater/StationsUpdaterTest.java
+++ b/src/test/java/org/entur/lamassu/leader/entityupdater/StationsUpdaterTest.java
@@ -117,7 +117,7 @@ class StationsUpdaterTest {
     stationStatus.setIsInstalled(true);
     stationStatus.setIsRenting(true);
     stationStatus.setIsReturning(true);
-    stationStatus.setLastReported(new Date());
+    stationStatus.setLastReported(new Date(1000L));
 
     var stationInformationFeed = new GBFSStationInformation();
     var data = new GBFSData();
@@ -210,7 +210,7 @@ class StationsUpdaterTest {
     stationStatus.setIsInstalled(true);
     stationStatus.setIsRenting(true);
     stationStatus.setIsReturning(true);
-    stationStatus.setLastReported(new Date());
+    stationStatus.setLastReported(new Date(1000L));
 
     var stationInformationFeed = new GBFSStationInformation();
     var data = new GBFSData();
@@ -393,7 +393,7 @@ class StationsUpdaterTest {
     stationStatus.setIsInstalled(true);
     stationStatus.setIsRenting(true);
     stationStatus.setIsReturning(true);
-    stationStatus.setLastReported(new Date());
+    stationStatus.setLastReported(new Date(1000L));
     stationStatus.setVehicleTypesAvailable(
       new ArrayList<>(
         List.of(
@@ -538,7 +538,7 @@ class StationsUpdaterTest {
     stationStatus.setIsInstalled(true);
     stationStatus.setIsRenting(true);
     stationStatus.setIsReturning(true);
-    stationStatus.setLastReported(new Date());
+    stationStatus.setLastReported(new Date(1000L));
 
     var stationInformationFeed = new GBFSStationInformation();
     var data = new GBFSData();

--- a/src/test/java/org/entur/lamassu/leader/entityupdater/StationsUpdaterTest.java
+++ b/src/test/java/org/entur/lamassu/leader/entityupdater/StationsUpdaterTest.java
@@ -1,5 +1,7 @@
 package org.entur.lamassu.leader.entityupdater;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyMap;
@@ -260,13 +262,80 @@ class StationsUpdaterTest {
     );
 
     // When
-    stationsUpdater.update(feedProvider, delta, null);
+    var fullyApplied = stationsUpdater.update(feedProvider, delta, null);
 
-    // Then
+    // Then - the station remains in the cache (stale), so the update is still
+    // considered fully applied
+    assertTrue(fullyApplied);
     verify(spatialIndex, never()).addAll(anyMap());
     verify(spatialIndex, never()).removeAll(anySet());
     verify(stationCache, never()).updateAll(anyMap(), anyInt(), any(TimeUnit.class));
     verify(stationCache, never()).removeAll(anySet());
+  }
+
+  @Test
+  void shouldReportNotFullyAppliedWhenCreateSkippedDueToMissingStationInformation() {
+    // Given
+    var feedProvider = new FeedProvider();
+    feedProvider.setSystemId("test-system");
+
+    var stationId = "station-1";
+
+    var stationStatus = new org.mobilitydata.gbfs.v3_0.station_status.GBFSStation();
+    stationStatus.setStationId(stationId);
+    stationStatus.setNumVehiclesAvailable(5);
+
+    // Mock behavior
+    when(stationCache.get(stationId)).thenReturn(null);
+
+    var delta = new GBFSFileDelta<>(
+      1000L,
+      2000L,
+      "station_status",
+      List.of(new GBFSEntityDelta<>(stationId, DeltaType.CREATE, stationStatus))
+    );
+
+    // When - station information feed does not contain the new station
+    var fullyApplied = stationsUpdater.update(
+      feedProvider,
+      delta,
+      new GBFSStationInformation().withData(new GBFSData().withStations(List.of()))
+    );
+
+    // Then - the station could not be added, continuity must be broken
+    assertFalse(fullyApplied);
+    verify(stationCache, never()).updateAll(anyMap());
+  }
+
+  @Test
+  void shouldReportNotFullyAppliedWhenUpdatedStationIsMissingFromCache() {
+    // Given
+    var feedProvider = new FeedProvider();
+    feedProvider.setSystemId("test-system");
+
+    var stationId = "station-1";
+
+    var stationStatus = new org.mobilitydata.gbfs.v3_0.station_status.GBFSStation();
+    stationStatus.setStationId(stationId);
+    stationStatus.setNumVehiclesAvailable(5);
+
+    // Mock behavior - station is not in the entity cache
+    when(stationCache.get(stationId)).thenReturn(null);
+
+    var delta = new GBFSFileDelta<>(
+      1000L,
+      2000L,
+      "station_status",
+      List.of(new GBFSEntityDelta<>(stationId, DeltaType.UPDATE, stationStatus))
+    );
+
+    // When
+    var fullyApplied = stationsUpdater.update(feedProvider, delta, null);
+
+    // Then - the station is missing from the cache and could not be recovered,
+    // continuity must be broken
+    assertFalse(fullyApplied);
+    verify(stationCache, never()).updateAll(anyMap());
   }
 
   @Test


### PR DESCRIPTION
## Problem

We had several production incidents where a station was present in the GBFS endpoints but missing from the entity caches / GraphQL API. In all cases, restarting the subscription (or disabling/re-enabling the provider) fixed it.

## Root cause

Entity cache updates are delta-driven on `station_status`, and a station's CREATE delta is emitted exactly once — when it first appears compared to the previous status. When a provider adds a station, it can appear in `station_status` before it is visible in `station_information` (the files are fetched on independent TTL schedules — `station_information` typically has a long TTL — and providers do not update files atomically).

In that case:

1. `StationsUpdater.processDeltaCreate` drops the CREATE because the station is missing from `station_information` (logged as *"Skipping station due to missing station information feed"*).
2. Update continuity is still recorded, so the next poll's delta base already contains the station — no CREATE is ever emitted again.
3. Subsequent UPDATE deltas are also dropped, because the station is not in the entity cache.

Meanwhile the feed caches store the raw feeds verbatim, so the station remains visible at the GBFS endpoints the whole time. Restarting the subscription healed it because continuity was cleared, triggering a full rebuild with complete station information.

## Fix

`StationsUpdater.update` now reports whether the delta was fully applied. It reports `false` when a station ends up absent from the entity cache with no retry path:

- a CREATE skipped because the station is missing from `station_information`
- an UPDATE for a station that is not in the entity cache (the symptom of an earlier dropped CREATE, or any other cache divergence)

When that happens, `EntityCachesUpdater` clears station update continuity instead of recording it, forcing a full rebuild on the next update — which picks up the station once its station information has become available. An UPDATE skipped for missing station information while the station is still cached does **not** break continuity (the station stays present, just stale).

Note: `VehiclesUpdater` already self-heals the analogous case by falling back to creation when an UPDATE references an uncached vehicle, which is possible there because vehicle creation has no hard cross-feed dependency.

## Behavioral note

A chronically non-compliant provider (a station permanently in `station_status` but never in `station_information`) will now trigger a full station rebuild on every poll for that system, with a warning logged each time. Previously such a station was silently lost.

## Tests

- `EntityCachesUpdaterStationInformationLagTest` reproduces the production sequence end-to-end (real delta calculator, real `StationsUpdater`, real continuity tracker) and verifies the station appears once `station_information` catches up. It fails without the fix.
- New unit tests in `StationsUpdaterTest` pin the fully-applied reporting for the dropped-CREATE and uncached-UPDATE cases.