### PR TITLE
Include scooter_standing when filtering vehicles by the deprecated SCOOTER form factor

### DIFF
--- a/src/main/java/org/entur/lamassu/graphql/query/StationQueryController.java
+++ b/src/main/java/org/entur/lamassu/graphql/query/StationQueryController.java
@@ -68,7 +68,7 @@ public class StationQueryController {
       systems,
       operators,
       count,
-      availableFormFactors,
+      FormFactor.expandFormFactorFilter(availableFormFactors),
       availablePropulsionTypes
     );
 

--- a/src/main/java/org/entur/lamassu/graphql/query/VehicleQueryController.java
+++ b/src/main/java/org/entur/lamassu/graphql/query/VehicleQueryController.java
@@ -70,7 +70,7 @@ public class VehicleQueryController {
       systems,
       operators,
       count,
-      formFactors,
+      FormFactor.expandFormFactorFilter(formFactors),
       propulsionTypes,
       includeReserved,
       includeDisabled

--- a/src/main/java/org/entur/lamassu/graphql/subscription/VehicleSubscriptionController.java
+++ b/src/main/java/org/entur/lamassu/graphql/subscription/VehicleSubscriptionController.java
@@ -93,7 +93,7 @@ public class VehicleSubscriptionController {
       systems,
       operators,
       null, // count is not applicable for subscriptions
-      formFactors,
+      FormFactor.expandFormFactorFilter(formFactors),
       propulsionTypes,
       includeReserved != null && includeReserved,
       includeDisabled != null && includeDisabled

--- a/src/main/java/org/entur/lamassu/model/entities/FormFactor.java
+++ b/src/main/java/org/entur/lamassu/model/entities/FormFactor.java
@@ -1,5 +1,8 @@
 package org.entur.lamassu.model.entities;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public enum FormFactor {
   BICYCLE,
   CARGO_BICYCLE,
@@ -8,5 +11,29 @@ public enum FormFactor {
   SCOOTER,
   SCOOTER_STANDING,
   SCOOTER_SEATED,
-  OTHER,
+  OTHER;
+
+  /**
+   * Expands a requested form-factor filter so the deprecated {@link #SCOOTER} value also matches
+   * {@link #SCOOTER_STANDING}.
+   *
+   * <p>GBFS v3 split the v2 {@code scooter} form factor into {@code scooter_standing} and
+   * {@code scooter_seated}, mapping the classic standing e-scooter to {@code scooter_standing}.
+   * Since vehicles are now mapped from the v3 model, a client filtering on the (deprecated)
+   * {@code SCOOTER} value would otherwise no longer match those vehicles.
+   *
+   * @param requested the requested form factors, or {@code null} for no filter
+   * @return the requested form factors with {@link #SCOOTER_STANDING} added when {@link #SCOOTER}
+   *     is present; the input is returned unchanged otherwise
+   */
+  public static List<FormFactor> expandFormFactorFilter(List<FormFactor> requested) {
+    if (requested == null || !requested.contains(SCOOTER)) {
+      return requested;
+    }
+    List<FormFactor> expanded = new ArrayList<>(requested);
+    if (!expanded.contains(SCOOTER_STANDING)) {
+      expanded.add(SCOOTER_STANDING);
+    }
+    return expanded;
+  }
 }

--- a/src/test/java/org/entur/lamassu/integration/GraphQLIntegrationTest.java
+++ b/src/test/java/org/entur/lamassu/integration/GraphQLIntegrationTest.java
@@ -55,6 +55,25 @@ class GraphQLIntegrationTest extends AbstractIntegrationTestBase {
   }
 
   @Test
+  void testScooterFilterIncludesScooterStanding() {
+    // The deprecated SCOOTER form factor must still match vehicles mapped to the GBFS v3
+    // SCOOTER_STANDING form factor (see FormFactor#expandFormFactorFilter).
+    Response response = graphQlTester
+      .documentName("vehicles_query_scooter_filter")
+      .execute();
+
+    response.path("vehicles").entityList(Object.class).hasSize(1);
+    response
+      .path("vehicles[0].id")
+      .entity(String.class)
+      .isEqualTo("OZO:Vehicle:987fd100-b822-4347-86a4-b3eef8ca8b53");
+    response
+      .path("vehicles[0].vehicleType.formFactor")
+      .entity(String.class)
+      .isEqualTo("SCOOTER_STANDING");
+  }
+
+  @Test
   void testStationsQuery() {
     Response response = graphQlTester.documentName("stations_query").execute();
 

--- a/src/test/java/org/entur/lamassu/model/entities/FormFactorTest.java
+++ b/src/test/java/org/entur/lamassu/model/entities/FormFactorTest.java
@@ -1,0 +1,50 @@
+package org.entur.lamassu.model.entities;
+
+import java.util.List;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class FormFactorTest {
+
+  @Test
+  public void scooterFilterAlsoMatchesScooterStanding() {
+    // GBFS v3 split the v2 "scooter" form factor into scooter_standing/scooter_seated.
+    // Vehicles from v2 feeds are now mapped to SCOOTER_STANDING, so a filter on the
+    // deprecated SCOOTER value must still include them.
+    List<FormFactor> expanded = FormFactor.expandFormFactorFilter(
+      List.of(FormFactor.SCOOTER)
+    );
+    Assert.assertTrue(expanded.contains(FormFactor.SCOOTER));
+    Assert.assertTrue(expanded.contains(FormFactor.SCOOTER_STANDING));
+  }
+
+  @Test
+  public void scooterFilterDoesNotMatchScooterSeated() {
+    List<FormFactor> expanded = FormFactor.expandFormFactorFilter(
+      List.of(FormFactor.SCOOTER)
+    );
+    Assert.assertFalse(expanded.contains(FormFactor.SCOOTER_SEATED));
+  }
+
+  @Test
+  public void nonScooterFiltersAreUnchanged() {
+    List<FormFactor> requested = List.of(FormFactor.BICYCLE, FormFactor.MOPED);
+    Assert.assertEquals(requested, FormFactor.expandFormFactorFilter(requested));
+  }
+
+  @Test
+  public void scooterStandingFilterIsNotDuplicated() {
+    List<FormFactor> expanded = FormFactor.expandFormFactorFilter(
+      List.of(FormFactor.SCOOTER, FormFactor.SCOOTER_STANDING)
+    );
+    Assert.assertEquals(
+      1,
+      expanded.stream().filter(f -> f == FormFactor.SCOOTER_STANDING).count()
+    );
+  }
+
+  @Test
+  public void nullFilterReturnsNull() {
+    Assert.assertNull(FormFactor.expandFormFactorFilter(null));
+  }
+}

--- a/src/test/resources/graphql-test/vehicles_query_scooter_filter.graphql
+++ b/src/test/resources/graphql-test/vehicles_query_scooter_filter.graphql
@@ -1,0 +1,13 @@
+{
+    vehicles(
+        lat: 12.345678,
+        lon: 56.789012,
+        range: 500,
+        formFactors: [SCOOTER]
+    ) {
+        id
+        vehicleType {
+            formFactor
+        }
+    }
+}

--- a/src/test/resources/v3/vehicle_status.json
+++ b/src/test/resources/v3/vehicle_status.json
@@ -21,12 +21,12 @@
       {
         "vehicle_id":"987fd100-b822-4347-86a4-b3eef8ca8b53",
         "last_reported":"2021-01-05T18:03:24+01:00",
+        "lat":12.345678,
+        "lon":56.789012,
         "is_reserved":false,
         "is_disabled":false,
         "vehicle_type_id":"def456",
-        "current_range_meters":6543.0,
-        "station_id":"86",
-        "pricing_plan_id":"plan3"
+        "current_range_meters":6543.0
       },
       {
         "vehicle_id":"45bd3fb7-a2d5-4def-9de1-c645844ba962",


### PR DESCRIPTION
## Problem
After the recent `gbfs-java-model` / `gbfs-mapper-java` upgrade, filtering the GraphQL API by form factor **`SCOOTER`** stopped returning scooters.

**Why:** GBFS v3 split the v2 `scooter` form factor into `scooter_standing` + `scooter_seated`, mapping the classic standing e-scooter to `scooter_standing`. `VehicleTypeMapper` now maps from the **v3.0** model (`org.mobilitydata.gbfs.v3_0…`, whose enum has no plain `scooter`), so every former "scooter" vehicle is stored internally as `SCOOTER_STANDING`. The vehicle filter is an exact match (`requestedFormFactors.contains(vehicle.formFactor)`), so a request for the still-valid, deprecated `SCOOTER` value matched nothing.

The schema already documents the intended equivalence: `SCOOTER @deprecated(reason: "Use SCOOTER_STANDING")`.

## Fix
`FormFactor.expandFormFactorFilter(...)` expands a requested filter so **`SCOOTER` also matches `SCOOTER_STANDING`** (not `SCOOTER_SEATED` — a genuinely different, seated vehicle). It's applied wherever form factors are filtered, for consistent behaviour:
- `VehicleQueryController` (`formFactors`)
- `StationQueryController` (`availableFormFactors`)
- `VehicleSubscriptionController` (`formFactors`)

No schema change; the deprecated `SCOOTER` value simply behaves as an alias again.

## Tests (TDD)
- **`FormFactorTest`** — unit-tests the expansion (SCOOTER → +SCOOTER_STANDING, excludes SCOOTER_SEATED, no duplication, null-safe, non-scooter unchanged).
- **`GraphQLIntegrationTest#testScooterFilterIncludesScooterStanding`** — end-to-end: a `formFactors: [SCOOTER]` query returns a `scooter_standing` vehicle. Verified it fails (`vehicles: []`, the exact bug) without the fix and passes with it.
- A v3 fixture vehicle (`987fd100`) was made a valid free-floating `scooter_standing` (it was docked with a dangling pricing-plan reference, so it wasn't spatially indexed).
- Full suite green: **295 tests, 0 failures**.

Independent of the Spring Boot 4 (#877) and frontend (#878) dependency PRs — branched off `master`.