### PR TITLE
Make subscription status durable and report data freshness separately

### DIFF
--- a/src/main/java/org/entur/lamassu/leader/FeedUpdater.java
+++ b/src/main/java/org/entur/lamassu/leader/FeedUpdater.java
@@ -231,12 +231,9 @@ public class FeedUpdater {
         feedProvider.getSystemId()
       );
       metricsService.registerSubscriptionSetup(feedProvider, false);
-      // Keep the durable status as STARTING while a retry is pending, so the feed
-      // is never reported as absent/STOPPED during setup.
-      subscriptionRegistry.updateSubscriptionStatus(
-        feedProvider.getSystemId(),
-        SubscriptionStatus.STARTING
-      );
+      // The durable status is left untouched (STARTING, set by the caller) while a
+      // retry is pending, so the feed is never reported as absent/STOPPED during
+      // setup. Nothing here clears it.
       CompletableFuture
         .delayedExecutor(SUBSCRIPTION_SETUP_RETRY_DELAY_SECONDS, TimeUnit.SECONDS)
         .execute(() ->

--- a/src/main/java/org/entur/lamassu/leader/FeedUpdater.java
+++ b/src/main/java/org/entur/lamassu/leader/FeedUpdater.java
@@ -106,7 +106,9 @@ public class FeedUpdater {
 
   public void start() {
     cacheCleanupService.clearCache();
-    subscriptionRegistry.clear(); // Clear any existing subscription registrations
+    // Clear only per-pod in-memory ids; the durable desired-state survives so a
+    // stopped subscription is not auto-resubscribed on a new leader.
+    subscriptionRegistry.clearInMemory();
     updaterThreadPool =
       new ForkJoinPool(
         NUM_CORES * 2,
@@ -123,15 +125,27 @@ public class FeedUpdater {
   }
 
   public void stop() {
-    subscriptionRegistry.clear();
+    subscriptionRegistry.clearInMemory();
     updaterThreadPool.shutdown();
   }
 
-  private void createSubscriptions() {
+  /**
+   * Whether a provider should have a subscription started. Enabled providers are
+   * subscribed unless their subscription has been explicitly stopped (a durable
+   * desired-state that survives leader restarts).
+   */
+  boolean shouldSubscribe(FeedProvider feedProvider) {
+    return (
+      Boolean.TRUE.equals(feedProvider.getEnabled()) &&
+      !subscriptionRegistry.isStopped(feedProvider.getSystemId())
+    );
+  }
+
+  void createSubscriptions() {
     feedProviderConfig
       .getProviders()
       .parallelStream()
-      .filter(feedProvider -> Boolean.TRUE.equals(feedProvider.getEnabled()))
+      .filter(this::shouldSubscribe)
       .forEach(feedProvider -> {
         // Set status to STARTING before creating subscription
         subscriptionRegistry.updateSubscriptionStatus(
@@ -142,7 +156,26 @@ public class FeedUpdater {
       });
   }
 
-  private void createSubscription(FeedProvider feedProvider) {
+  /**
+   * Retries a failed subscription setup, unless the feed has since been stopped
+   * (durable desired-state) or already has a live subscription. This prevents
+   * reviving stopped feeds and creating duplicate pollers via stale retries.
+   */
+  void maybeRetrySubscription(FeedProvider feedProvider) {
+    if (
+      !shouldSubscribe(feedProvider) ||
+      subscriptionRegistry.hasSubscription(feedProvider.getSystemId())
+    ) {
+      logger.info(
+        "Skipping subscription retry for systemId={} (stopped or already subscribed)",
+        feedProvider.getSystemId()
+      );
+      return;
+    }
+    createSubscription(feedProvider);
+  }
+
+  void createSubscription(FeedProvider feedProvider) {
     var options = new GbfsSubscriptionOptions(
       URI.create(feedProvider.getUrl()),
       feedProvider.getLanguage(),
@@ -198,9 +231,17 @@ public class FeedUpdater {
         feedProvider.getSystemId()
       );
       metricsService.registerSubscriptionSetup(feedProvider, false);
+      // Keep the durable status as STARTING while a retry is pending, so the feed
+      // is never reported as absent/STOPPED during setup.
+      subscriptionRegistry.updateSubscriptionStatus(
+        feedProvider.getSystemId(),
+        SubscriptionStatus.STARTING
+      );
       CompletableFuture
         .delayedExecutor(SUBSCRIPTION_SETUP_RETRY_DELAY_SECONDS, TimeUnit.SECONDS)
-        .execute(() -> updaterThreadPool.execute(() -> createSubscription(feedProvider)));
+        .execute(() ->
+          updaterThreadPool.execute(() -> maybeRetrySubscription(feedProvider))
+        );
     } else {
       logger.info("Setup subscription complete systemId={}", feedProvider.getSystemId());
       metricsService.registerSubscriptionSetup(feedProvider, true);
@@ -421,7 +462,10 @@ public class FeedUpdater {
     if (subscriptionId != null) {
       try {
         subscriptionManager.unsubscribe(subscriptionId);
-        subscriptionRegistry.removeSubscription(feedProvider.getSystemId());
+        // Remove only the in-memory id; keep the durable status (STARTING, set
+        // above) so the feed is never reported absent while the new subscription
+        // is established.
+        subscriptionRegistry.removeSubscriptionId(feedProvider.getSystemId());
       } catch (Exception e) {
         logger.warn(
           "Error unsubscribing during restart for systemId={}",

--- a/src/main/java/org/entur/lamassu/leader/SubscriptionRegistry.java
+++ b/src/main/java/org/entur/lamassu/leader/SubscriptionRegistry.java
@@ -74,6 +74,19 @@ public class SubscriptionRegistry {
   }
 
   /**
+   * Removes only the in-memory subscription id, preserving the durable status.
+   * Used when swapping a subscription (e.g. restart) so the reported status is
+   * never momentarily absent (which would read as STOPPED) while the new
+   * subscription is being established.
+   *
+   * @param systemId The system ID of the feed provider
+   */
+  public void removeSubscriptionId(String systemId) {
+    subscriptionIdsBySystemId.remove(systemId);
+    logger.debug("Removed in-memory subscription id for system ID {}", systemId);
+  }
+
+  /**
    * Gets the subscription ID for a system ID.
    *
    * @param systemId The system ID of the feed provider
@@ -93,6 +106,19 @@ public class SubscriptionRegistry {
   public SubscriptionStatus getSubscriptionStatusBySystemId(String systemId) {
     SubscriptionStatus status = subscriptionStatusCache.getStatus(systemId);
     return status != null ? status : SubscriptionStatus.STOPPED;
+  }
+
+  /**
+   * Whether a subscription has been explicitly stopped. Unlike
+   * {@link #getSubscriptionStatusBySystemId}, an absent (never-recorded) status is
+   * NOT treated as stopped. Used to decide whether a (re)starting leader should
+   * resubscribe a provider.
+   *
+   * @param systemId The system ID of the feed provider
+   * @return true only if the durable status is explicitly STOPPED
+   */
+  public boolean isStopped(String systemId) {
+    return subscriptionStatusCache.getStatus(systemId) == SubscriptionStatus.STOPPED;
   }
 
   /**
@@ -126,11 +152,21 @@ public class SubscriptionRegistry {
   }
 
   /**
-   * Clears all registered subscriptions.
+   * Clears all registered subscriptions, including the durable status cache.
    */
   public void clear() {
     subscriptionIdsBySystemId.clear();
     subscriptionStatusCache.clear();
     logger.debug("Cleared all subscription registrations");
+  }
+
+  /**
+   * Clears only the per-pod in-memory subscription ids, preserving the durable
+   * subscription desired-state in Redis. Called on leader (re)start so that a
+   * stopped subscription survives a restart instead of being auto-resubscribed.
+   */
+  public void clearInMemory() {
+    subscriptionIdsBySystemId.clear();
+    logger.debug("Cleared in-memory subscription ids (durable status preserved)");
   }
 }

--- a/src/main/java/org/entur/lamassu/metrics/MetricUpdater.java
+++ b/src/main/java/org/entur/lamassu/metrics/MetricUpdater.java
@@ -1,37 +1,29 @@
 package org.entur.lamassu.metrics;
 
-import java.lang.reflect.InvocationTargetException;
-import java.time.Instant;
 import java.util.Arrays;
-import java.util.Date;
-import org.entur.lamassu.cache.GBFSV3FeedCache;
 import org.entur.lamassu.config.feedprovider.FeedProviderConfig;
 import org.entur.lamassu.model.provider.FeedProvider;
+import org.entur.lamassu.service.FeedFreshnessService;
 import org.mobilitydata.gbfs.v3_0.gbfs.GBFSFeed;
-import org.mobilitydata.gbfs.v3_0.gbfs.GBFSFeedName;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
 public class MetricUpdater {
 
-  @Value("${org.entur.lamassu.max-tolerated-overdue-seconds:120}")
-  private Integer maxToleratedOverdueSeconds = 120;
-
   private final MetricsService metricsService;
   private final FeedProviderConfig feedProviderConfig;
-  private final GBFSV3FeedCache feedCache;
+  private final FeedFreshnessService feedFreshnessService;
 
   @Autowired
   public MetricUpdater(
     MetricsService metricsService,
     FeedProviderConfig feedProviderConfig,
-    GBFSV3FeedCache feedCache
+    FeedFreshnessService feedFreshnessService
   ) {
     this.metricsService = metricsService;
     this.feedProviderConfig = feedProviderConfig;
-    this.feedCache = feedCache;
+    this.feedFreshnessService = feedFreshnessService;
   }
 
   public void updateOutdatedFeedMetrics() {
@@ -47,30 +39,11 @@ public class MetricUpdater {
       .stream()
       // Since gbfs is not yet updated regularly, we skip it explicitly
       .filter(feedName -> !GBFSFeed.Name.GBFS.equals(feedName))
-      .mapToInt(feedName -> isFeedOverdue(feedProvider, feedName) ? 1 : 0)
+      .mapToInt(feedName ->
+        feedFreshnessService.isFeedOverdue(feedProvider, feedName) ? 1 : 0
+      )
       .sum();
 
     metricsService.registerOverdueFilesCount(feedProvider, overdueFilesCount);
-  }
-
-  private boolean isFeedOverdue(FeedProvider feedProvider, GBFSFeed.Name feedName) {
-    Object feed = feedCache.find(feedName, feedProvider);
-    if (feed != null) {
-      long absoluteTtl = getAbsoluteTtl(GBFSFeedName.implementingClass(feedName), feed);
-      return absoluteTtl + maxToleratedOverdueSeconds < Instant.now().getEpochSecond();
-    }
-    return false;
-  }
-
-  private <T> long getAbsoluteTtl(Class<?> feedClass, T feed) {
-    try {
-      Date lastUpdated = (Date) feedClass.getMethod("getLastUpdated").invoke(feed);
-      Integer ttl = (Integer) feedClass.getMethod("getTtl").invoke(feed);
-      return lastUpdated.getTime() / 1000 + ttl;
-    } catch (
-      NoSuchMethodException | InvocationTargetException | IllegalAccessException e
-    ) {
-      return 0;
-    }
   }
 }

--- a/src/main/java/org/entur/lamassu/model/dto/PublicFeedProviderStatus.java
+++ b/src/main/java/org/entur/lamassu/model/dto/PublicFeedProviderStatus.java
@@ -33,6 +33,8 @@ public class PublicFeedProviderStatus {
   private String version;
   private Boolean enabled;
   private SubscriptionStatus subscriptionStatus;
+  private boolean dataFresh;
+  private Long lastUpdated;
 
   // Default constructor
   public PublicFeedProviderStatus() {}
@@ -92,6 +94,30 @@ public class PublicFeedProviderStatus {
 
   public void setSubscriptionStatus(SubscriptionStatus subscriptionStatus) {
     this.subscriptionStatus = subscriptionStatus;
+  }
+
+  /**
+   * Whether the system is currently receiving fresh data (realtime feed present
+   * and not overdue). Independent of the subscription desired-state.
+   */
+  public boolean getDataFresh() {
+    return dataFresh;
+  }
+
+  public void setDataFresh(boolean dataFresh) {
+    this.dataFresh = dataFresh;
+  }
+
+  /**
+   * Epoch seconds of the most recent realtime feed update, or null if no
+   * realtime data is cached.
+   */
+  public Long getLastUpdated() {
+    return lastUpdated;
+  }
+
+  public void setLastUpdated(Long lastUpdated) {
+    this.lastUpdated = lastUpdated;
   }
 
   @Override

--- a/src/main/java/org/entur/lamassu/model/dto/PublicFeedProviderStatusMapper.java
+++ b/src/main/java/org/entur/lamassu/model/dto/PublicFeedProviderStatusMapper.java
@@ -18,9 +18,11 @@
 
 package org.entur.lamassu.model.dto;
 
+import java.time.Instant;
 import org.entur.lamassu.leader.SubscriptionRegistry;
 import org.entur.lamassu.leader.SubscriptionStatus;
 import org.entur.lamassu.model.provider.FeedProvider;
+import org.entur.lamassu.service.FeedFreshnessService;
 import org.springframework.stereotype.Component;
 
 /**
@@ -30,9 +32,14 @@ import org.springframework.stereotype.Component;
 public class PublicFeedProviderStatusMapper {
 
   private final SubscriptionRegistry subscriptionRegistry;
+  private final FeedFreshnessService freshnessService;
 
-  public PublicFeedProviderStatusMapper(SubscriptionRegistry subscriptionRegistry) {
+  public PublicFeedProviderStatusMapper(
+    SubscriptionRegistry subscriptionRegistry,
+    FeedFreshnessService freshnessService
+  ) {
     this.subscriptionRegistry = subscriptionRegistry;
+    this.freshnessService = freshnessService;
   }
 
   /**
@@ -55,6 +62,13 @@ public class PublicFeedProviderStatusMapper {
       provider.getSystemId()
     );
     dto.setSubscriptionStatus(status);
+
+    // Data freshness is derived from the cached feeds and reported separately
+    // from the (durable) subscription desired-state.
+    dto.setDataFresh(freshnessService.isLive(provider));
+    dto.setLastUpdated(
+      freshnessService.lastUpdated(provider).map(Instant::getEpochSecond).orElse(null)
+    );
 
     return dto;
   }

--- a/src/main/java/org/entur/lamassu/service/FeedFreshnessService.java
+++ b/src/main/java/org/entur/lamassu/service/FeedFreshnessService.java
@@ -1,0 +1,141 @@
+/*
+ *
+ *
+ *  * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ *  * the European Commission - subsequent versions of the EUPL (the "Licence");
+ *  * You may not use this work except in compliance with the Licence.
+ *  * You may obtain a copy of the Licence at:
+ *  *
+ *  *   https://joinup.ec.europa.eu/software/page/eupl
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the Licence is distributed on an "AS IS" basis,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the Licence for the specific language governing permissions and
+ *  * limitations under the Licence.
+ *
+ */
+
+package org.entur.lamassu.service;
+
+import java.lang.reflect.InvocationTargetException;
+import java.time.Instant;
+import java.util.Date;
+import java.util.Optional;
+import org.entur.lamassu.cache.GBFSV3FeedCache;
+import org.entur.lamassu.model.provider.FeedProvider;
+import org.mobilitydata.gbfs.v3_0.gbfs.GBFSFeed;
+import org.mobilitydata.gbfs.v3_0.gbfs.GBFSFeedName;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+/**
+ * Derives data-freshness signals for a feed provider from the cached GBFS feeds.
+ *
+ * <p>This reflects whether a system is actually receiving fresh data, independent
+ * of its (durable) subscription desired-state. It reads the shared feed cache, so
+ * it produces the same answer on leader and follower instances.
+ */
+@Service
+public class FeedFreshnessService {
+
+  private static final GBFSFeed.Name[] REALTIME_FEEDS = {
+    GBFSFeed.Name.VEHICLE_STATUS,
+    GBFSFeed.Name.STATION_STATUS,
+  };
+
+  private final GBFSV3FeedCache feedCache;
+  private final int maxToleratedOverdueSeconds;
+
+  public FeedFreshnessService(
+    GBFSV3FeedCache feedCache,
+    @Value(
+      "${org.entur.lamassu.max-tolerated-overdue-seconds:120}"
+    ) int maxToleratedOverdueSeconds
+  ) {
+    this.feedCache = feedCache;
+    this.maxToleratedOverdueSeconds = maxToleratedOverdueSeconds;
+  }
+
+  /**
+   * A system is considered live if at least one of its realtime feeds
+   * (vehicle_status or station_status) is present in the cache and not overdue.
+   */
+  public boolean isLive(FeedProvider feedProvider) {
+    for (GBFSFeed.Name feedName : REALTIME_FEEDS) {
+      if (isFeedFresh(feedProvider, feedName)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * The most recent last_updated timestamp across the system's realtime feeds,
+   * or empty if none are present.
+   */
+  public Optional<Instant> lastUpdated(FeedProvider feedProvider) {
+    Instant latest = null;
+    for (GBFSFeed.Name feedName : REALTIME_FEEDS) {
+      Instant timestamp = feedLastUpdated(feedProvider, feedName);
+      if (timestamp != null && (latest == null || timestamp.isAfter(latest))) {
+        latest = timestamp;
+      }
+    }
+    return Optional.ofNullable(latest);
+  }
+
+  /**
+   * Whether a specific feed file is overdue (present but past its ttl plus the
+   * tolerated overdue window). Absent feeds are not considered overdue.
+   */
+  public boolean isFeedOverdue(FeedProvider feedProvider, GBFSFeed.Name feedName) {
+    Object feed = feedCache.find(feedName, feedProvider);
+    if (feed != null) {
+      long absoluteTtl = getAbsoluteTtl(GBFSFeedName.implementingClass(feedName), feed);
+      return absoluteTtl + maxToleratedOverdueSeconds < Instant.now().getEpochSecond();
+    }
+    return false;
+  }
+
+  private boolean isFeedFresh(FeedProvider feedProvider, GBFSFeed.Name feedName) {
+    Object feed = feedCache.find(feedName, feedProvider);
+    if (feed == null) {
+      return false;
+    }
+    long absoluteTtl = getAbsoluteTtl(GBFSFeedName.implementingClass(feedName), feed);
+    return absoluteTtl + maxToleratedOverdueSeconds >= Instant.now().getEpochSecond();
+  }
+
+  private Instant feedLastUpdated(FeedProvider feedProvider, GBFSFeed.Name feedName) {
+    Object feed = feedCache.find(feedName, feedProvider);
+    if (feed == null) {
+      return null;
+    }
+    try {
+      Date lastUpdated = (Date) GBFSFeedName
+        .implementingClass(feedName)
+        .getMethod("getLastUpdated")
+        .invoke(feed);
+      return lastUpdated == null
+        ? null
+        : Instant.ofEpochSecond(lastUpdated.getTime() / 1000);
+    } catch (
+      NoSuchMethodException | InvocationTargetException | IllegalAccessException e
+    ) {
+      return null;
+    }
+  }
+
+  private <T> long getAbsoluteTtl(Class<?> feedClass, T feed) {
+    try {
+      Date lastUpdated = (Date) feedClass.getMethod("getLastUpdated").invoke(feed);
+      Integer ttl = (Integer) feedClass.getMethod("getTtl").invoke(feed);
+      return lastUpdated.getTime() / 1000 + ttl;
+    } catch (
+      NoSuchMethodException | InvocationTargetException | IllegalAccessException e
+    ) {
+      return 0;
+    }
+  }
+}

--- a/src/test/java/org/entur/lamassu/leader/FeedUpdaterSubscriptionTest.java
+++ b/src/test/java/org/entur/lamassu/leader/FeedUpdaterSubscriptionTest.java
@@ -217,15 +217,16 @@ class FeedUpdaterSubscriptionTest {
   }
 
   @Test
-  void createSubscription_keepsStartingStatus_whenSetupFails() {
+  void createSubscription_doesNotClearStatus_whenSetupFails() {
     testProvider.setEnabled(true);
-    // subscriptionManager.subscribeV2 returns null by default -> setup fails
+    // subscriptionManager.subscribeV2 returns null by default -> setup fails.
+    // The durable status (STARTING, set by the caller) must be left intact: the
+    // failure path must not remove it or mark the feed STOPPED.
     feedUpdater.createSubscription(testProvider);
 
-    verify(subscriptionRegistry)
-      .updateSubscriptionStatus(SYSTEM_ID, SubscriptionStatus.STARTING);
-    // never left absent
     verify(subscriptionRegistry, never()).removeSubscription(SYSTEM_ID);
+    verify(subscriptionRegistry, never())
+      .updateSubscriptionStatus(SYSTEM_ID, SubscriptionStatus.STOPPED);
   }
 
   @Test

--- a/src/test/java/org/entur/lamassu/leader/FeedUpdaterSubscriptionTest.java
+++ b/src/test/java/org/entur/lamassu/leader/FeedUpdaterSubscriptionTest.java
@@ -1,14 +1,18 @@
 package org.entur.lamassu.leader;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.concurrent.ForkJoinPool;
 import org.entur.gbfs.GbfsSubscriptionManager;
 import org.entur.lamassu.cache.SubscriptionStatusCache;
@@ -206,7 +210,52 @@ class FeedUpdaterSubscriptionTest {
     verify(subscriptionRegistry)
       .updateSubscriptionStatus(SYSTEM_ID, SubscriptionStatus.STARTING);
     verify(subscriptionManager).unsubscribe(SUBSCRIPTION_ID);
-    verify(subscriptionRegistry).removeSubscription(SYSTEM_ID);
+    // Restart removes only the in-memory id, preserving the durable status so the
+    // feed is never momentarily reported as absent/STOPPED.
+    verify(subscriptionRegistry).removeSubscriptionId(SYSTEM_ID);
+    verify(subscriptionRegistry, never()).removeSubscription(SYSTEM_ID);
+  }
+
+  @Test
+  void createSubscription_keepsStartingStatus_whenSetupFails() {
+    testProvider.setEnabled(true);
+    // subscriptionManager.subscribeV2 returns null by default -> setup fails
+    feedUpdater.createSubscription(testProvider);
+
+    verify(subscriptionRegistry)
+      .updateSubscriptionStatus(SYSTEM_ID, SubscriptionStatus.STARTING);
+    // never left absent
+    verify(subscriptionRegistry, never()).removeSubscription(SYSTEM_ID);
+  }
+
+  @Test
+  void maybeRetrySubscription_skipsWhenStopped() {
+    testProvider.setEnabled(true);
+    when(subscriptionStatusCache.getStatus(SYSTEM_ID))
+      .thenReturn(SubscriptionStatus.STOPPED);
+
+    feedUpdater.maybeRetrySubscription(testProvider);
+
+    verify(subscriptionManager, never()).subscribeV2(any(), any(), any());
+  }
+
+  @Test
+  void maybeRetrySubscription_skipsWhenAlreadySubscribed() {
+    testProvider.setEnabled(true);
+    subscriptionRegistry.registerSubscription(SYSTEM_ID, SUBSCRIPTION_ID);
+
+    feedUpdater.maybeRetrySubscription(testProvider);
+
+    verify(subscriptionManager, never()).subscribeV2(any(), any(), any());
+  }
+
+  @Test
+  void maybeRetrySubscription_subscribesWhenEligible() {
+    testProvider.setEnabled(true);
+
+    feedUpdater.maybeRetrySubscription(testProvider);
+
+    verify(subscriptionManager).subscribeV2(any(), any(), any());
   }
 
   @Test
@@ -220,6 +269,60 @@ class FeedUpdaterSubscriptionTest {
     verify(subscriptionRegistry)
       .updateSubscriptionStatus(SYSTEM_ID, SubscriptionStatus.STARTING);
     verify(subscriptionManager, never()).unsubscribe(anyString());
+  }
+
+  @Test
+  void shouldSubscribe_trueForEnabledNotStopped() {
+    testProvider.setEnabled(true);
+    assertTrue(feedUpdater.shouldSubscribe(testProvider));
+  }
+
+  @Test
+  void shouldSubscribe_falseForEnabledButStopped() {
+    testProvider.setEnabled(true);
+    when(subscriptionStatusCache.getStatus(SYSTEM_ID))
+      .thenReturn(SubscriptionStatus.STOPPED);
+    assertFalse(feedUpdater.shouldSubscribe(testProvider));
+  }
+
+  @Test
+  void shouldSubscribe_falseForDisabled() {
+    testProvider.setEnabled(false);
+    assertFalse(feedUpdater.shouldSubscribe(testProvider));
+  }
+
+  @Test
+  void stop_clearsInMemoryButPreservesDurableStatus() {
+    feedUpdater.stop();
+
+    verify(subscriptionRegistry).clearInMemory();
+    verify(subscriptionRegistry, never()).clear();
+  }
+
+  @Test
+  void createSubscriptions_skipsStoppedProviders() {
+    FeedProvider started = new FeedProvider();
+    started.setSystemId("started-system");
+    started.setUrl("http://started.url/gbfs");
+    started.setLanguage("en");
+    started.setEnabled(true);
+
+    FeedProvider stopped = new FeedProvider();
+    stopped.setSystemId("stopped-system");
+    stopped.setUrl("http://stopped.url/gbfs");
+    stopped.setLanguage("en");
+    stopped.setEnabled(true);
+
+    when(feedProviderConfig.getProviders()).thenReturn(List.of(started, stopped));
+    when(subscriptionStatusCache.getStatus("stopped-system"))
+      .thenReturn(SubscriptionStatus.STOPPED);
+
+    feedUpdater.createSubscriptions();
+
+    verify(subscriptionRegistry, atLeastOnce())
+      .updateSubscriptionStatus("started-system", SubscriptionStatus.STARTING);
+    verify(subscriptionRegistry, never())
+      .updateSubscriptionStatus("stopped-system", SubscriptionStatus.STARTING);
   }
 
   @Test

--- a/src/test/java/org/entur/lamassu/leader/SubscriptionRegistryTest.java
+++ b/src/test/java/org/entur/lamassu/leader/SubscriptionRegistryTest.java
@@ -177,6 +177,56 @@ class SubscriptionRegistryTest {
   }
 
   @Test
+  void clearInMemory_preservesDurableStatus() {
+    // Register a subscription (in-memory id + durable STARTED status)
+    subscriptionRegistry.registerSubscription(SYSTEM_ID, SUBSCRIPTION_ID);
+
+    // Simulate a leader restart clearing only per-pod in-memory state
+    subscriptionRegistry.clearInMemory();
+
+    // In-memory subscription id is gone...
+    assertFalse(subscriptionRegistry.hasSubscription(SYSTEM_ID));
+    assertNull(subscriptionRegistry.getSubscriptionIdBySystemId(SYSTEM_ID));
+    // ...but the durable desired-state survives
+    assertEquals(
+      SubscriptionStatus.STARTED,
+      subscriptionRegistry.getSubscriptionStatusBySystemId(SYSTEM_ID)
+    );
+  }
+
+  @Test
+  void removeSubscriptionId_removesIdButKeepsDurableStatus() {
+    subscriptionRegistry.registerSubscription(SYSTEM_ID, SUBSCRIPTION_ID);
+
+    subscriptionRegistry.removeSubscriptionId(SYSTEM_ID);
+
+    assertFalse(subscriptionRegistry.hasSubscription(SYSTEM_ID));
+    assertNull(subscriptionRegistry.getSubscriptionIdBySystemId(SYSTEM_ID));
+    // Durable status is NOT cleared (unlike removeSubscription)
+    assertEquals(
+      SubscriptionStatus.STARTED,
+      subscriptionRegistry.getSubscriptionStatusBySystemId(SYSTEM_ID)
+    );
+  }
+
+  @Test
+  void isStopped_returnsFalse_whenStatusAbsent() {
+    assertFalse(subscriptionRegistry.isStopped("absent-system"));
+  }
+
+  @Test
+  void isStopped_returnsTrue_whenStoredStopped() {
+    subscriptionRegistry.updateSubscriptionStatus(SYSTEM_ID, SubscriptionStatus.STOPPED);
+    assertTrue(subscriptionRegistry.isStopped(SYSTEM_ID));
+  }
+
+  @Test
+  void isStopped_returnsFalse_whenStarted() {
+    subscriptionRegistry.registerSubscription(SYSTEM_ID, SUBSCRIPTION_ID);
+    assertFalse(subscriptionRegistry.isStopped(SYSTEM_ID));
+  }
+
+  @Test
   void testDefaultStatusForNonExistentSystem() {
     // Verify that a non-existent system ID returns STOPPED status
     assertEquals(

--- a/src/test/java/org/entur/lamassu/metrics/MetricsUpdaterTest.java
+++ b/src/test/java/org/entur/lamassu/metrics/MetricsUpdaterTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 import org.entur.lamassu.cache.GBFSV3FeedCache;
 import org.entur.lamassu.config.feedprovider.FeedProviderConfig;
 import org.entur.lamassu.model.provider.FeedProvider;
+import org.entur.lamassu.service.FeedFreshnessService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mobilitydata.gbfs.v3_0.gbfs.GBFSFeed;
@@ -28,7 +29,11 @@ public class MetricsUpdaterTest {
     aFeedProvider.setSystemId("TestSystem");
     when(mockedFeedProviderConfig.getProviders()).thenReturn(List.of(aFeedProvider));
     metricUpdater =
-      new MetricUpdater(mockedMetricsService, mockedFeedProviderConfig, mockedFeedCache);
+      new MetricUpdater(
+        mockedMetricsService,
+        mockedFeedProviderConfig,
+        new FeedFreshnessService(mockedFeedCache, 120)
+      );
   }
 
   @Test

--- a/src/test/java/org/entur/lamassu/model/dto/PublicFeedProviderStatusMapperTest.java
+++ b/src/test/java/org/entur/lamassu/model/dto/PublicFeedProviderStatusMapperTest.java
@@ -21,11 +21,14 @@ package org.entur.lamassu.model.dto;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.time.Instant;
+import java.util.Optional;
 import org.entur.lamassu.leader.SubscriptionRegistry;
 import org.entur.lamassu.leader.SubscriptionStatus;
 import org.entur.lamassu.model.provider.Authentication;
 import org.entur.lamassu.model.provider.AuthenticationScheme;
 import org.entur.lamassu.model.provider.FeedProvider;
+import org.entur.lamassu.service.FeedFreshnessService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -36,12 +39,51 @@ class PublicFeedProviderStatusMapperTest {
   @Mock
   private SubscriptionRegistry subscriptionRegistry;
 
+  @Mock
+  private FeedFreshnessService freshnessService;
+
   private PublicFeedProviderStatusMapper mapper;
 
   @BeforeEach
   void setUp() {
     MockitoAnnotations.openMocks(this);
-    mapper = new PublicFeedProviderStatusMapper(subscriptionRegistry);
+    mapper = new PublicFeedProviderStatusMapper(subscriptionRegistry, freshnessService);
+  }
+
+  @Test
+  void testToPublicStatus_setsDataFreshAndLastUpdated_whenLive() {
+    FeedProvider provider = new FeedProvider();
+    provider.setSystemId("boltoslo");
+    provider.setEnabled(true);
+
+    long ts = Instant.now().getEpochSecond() - 30;
+    when(subscriptionRegistry.getSubscriptionStatusBySystemId("boltoslo"))
+      .thenReturn(SubscriptionStatus.STARTED);
+    when(freshnessService.isLive(provider)).thenReturn(true);
+    when(freshnessService.lastUpdated(provider))
+      .thenReturn(Optional.of(Instant.ofEpochSecond(ts)));
+
+    PublicFeedProviderStatus result = mapper.toPublicStatus(provider);
+
+    assertTrue(result.getDataFresh());
+    assertEquals(ts, result.getLastUpdated());
+  }
+
+  @Test
+  void testToPublicStatus_dataFreshFalseAndLastUpdatedNull_whenNotLive() {
+    FeedProvider provider = new FeedProvider();
+    provider.setSystemId("deadfeed");
+    provider.setEnabled(true);
+
+    when(subscriptionRegistry.getSubscriptionStatusBySystemId("deadfeed"))
+      .thenReturn(SubscriptionStatus.STARTED);
+    when(freshnessService.isLive(provider)).thenReturn(false);
+    when(freshnessService.lastUpdated(provider)).thenReturn(Optional.empty());
+
+    PublicFeedProviderStatus result = mapper.toPublicStatus(provider);
+
+    assertFalse(result.getDataFresh());
+    assertNull(result.getLastUpdated());
   }
 
   @Test

--- a/src/test/java/org/entur/lamassu/service/FeedFreshnessServiceTest.java
+++ b/src/test/java/org/entur/lamassu/service/FeedFreshnessServiceTest.java
@@ -1,0 +1,134 @@
+/*
+ *
+ *
+ *  * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ *  * the European Commission - subsequent versions of the EUPL (the "Licence");
+ *  * You may not use this work except in compliance with the Licence.
+ *  * You may obtain a copy of the Licence at:
+ *  *
+ *  *   https://joinup.ec.europa.eu/software/page/eupl
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the Licence is distributed on an "AS IS" basis,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the Licence for the specific language governing permissions and
+ *  * limitations under the Licence.
+ *
+ */
+
+package org.entur.lamassu.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.Optional;
+import org.entur.lamassu.cache.GBFSV3FeedCache;
+import org.entur.lamassu.model.provider.FeedProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mobilitydata.gbfs.v3_0.gbfs.GBFSFeed;
+import org.mobilitydata.gbfs.v3_0.station_status.GBFSStationStatus;
+import org.mobilitydata.gbfs.v3_0.vehicle_status.GBFSVehicleStatus;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class FeedFreshnessServiceTest {
+
+  private static final int MAX_TOLERATED_OVERDUE_SECONDS = 120;
+
+  @Mock
+  private GBFSV3FeedCache feedCache;
+
+  private FeedFreshnessService service;
+  private FeedProvider provider;
+
+  @BeforeEach
+  void setUp() {
+    service = new FeedFreshnessService(feedCache, MAX_TOLERATED_OVERDUE_SECONDS);
+    provider = new FeedProvider();
+    provider.setSystemId("boltoslo");
+  }
+
+  private GBFSVehicleStatus vehicleStatus(long lastUpdatedEpochSec, int ttl) {
+    return new GBFSVehicleStatus()
+      .withLastUpdated(new Date(lastUpdatedEpochSec * 1000))
+      .withTtl(ttl);
+  }
+
+  private GBFSStationStatus stationStatus(long lastUpdatedEpochSec, int ttl) {
+    return new GBFSStationStatus()
+      .withLastUpdated(new Date(lastUpdatedEpochSec * 1000))
+      .withTtl(ttl);
+  }
+
+  private long now() {
+    return Instant.now().getEpochSecond();
+  }
+
+  @Test
+  void isLive_returnsTrue_whenVehicleStatusIsFresh() {
+    when(feedCache.find(eq(GBFSFeed.Name.VEHICLE_STATUS), any()))
+      .thenReturn(vehicleStatus(now(), 60));
+
+    assertTrue(service.isLive(provider));
+  }
+
+  @Test
+  void isLive_returnsTrue_whenStationStatusIsFresh() {
+    when(feedCache.find(eq(GBFSFeed.Name.STATION_STATUS), any()))
+      .thenReturn(stationStatus(now(), 60));
+
+    assertTrue(service.isLive(provider));
+  }
+
+  @Test
+  void isLive_returnsFalse_whenVehicleStatusIsOverdue() {
+    when(feedCache.find(eq(GBFSFeed.Name.VEHICLE_STATUS), any()))
+      .thenReturn(vehicleStatus(now() - 1000, 60));
+
+    assertFalse(service.isLive(provider));
+  }
+
+  @Test
+  void isLive_returnsFalse_whenNoRealtimeFeedIsPresent() {
+    assertFalse(service.isLive(provider));
+  }
+
+  @Test
+  void lastUpdated_returnsVehicleStatusTimestamp_whenPresent() {
+    long ts = now() - 30;
+    when(feedCache.find(eq(GBFSFeed.Name.VEHICLE_STATUS), any()))
+      .thenReturn(vehicleStatus(ts, 60));
+
+    assertEquals(Optional.of(Instant.ofEpochSecond(ts)), service.lastUpdated(provider));
+  }
+
+  @Test
+  void lastUpdated_returnsEmpty_whenNoRealtimeFeedIsPresent() {
+    assertEquals(Optional.empty(), service.lastUpdated(provider));
+  }
+
+  @Test
+  void isFeedOverdue_returnsFalse_whenFeedIsAbsent() {
+    assertFalse(service.isFeedOverdue(provider, GBFSFeed.Name.VEHICLE_STATUS));
+  }
+
+  @Test
+  void isFeedOverdue_returnsTrue_whenPastTtlPlusTolerance() {
+    when(feedCache.find(eq(GBFSFeed.Name.VEHICLE_STATUS), any()))
+      .thenReturn(vehicleStatus(now() - 1000, 60));
+
+    assertTrue(service.isFeedOverdue(provider, GBFSFeed.Name.VEHICLE_STATUS));
+  }
+}

--- a/ui/src/pages/PublicFeedProviders.tsx
+++ b/ui/src/pages/PublicFeedProviders.tsx
@@ -89,6 +89,23 @@ export default function PublicFeedProviders() {
     }
   };
 
+  const formatLastUpdated = (lastUpdated: number | null) => {
+    if (!lastUpdated) {
+      return '—';
+    }
+    const seconds = Math.max(0, Math.floor(Date.now() / 1000 - lastUpdated));
+    if (seconds < 60) {
+      return `${seconds}s ago`;
+    }
+    if (seconds < 3600) {
+      return `${Math.floor(seconds / 60)}m ago`;
+    }
+    if (seconds < 86400) {
+      return `${Math.floor(seconds / 3600)}h ago`;
+    }
+    return `${Math.floor(seconds / 86400)}d ago`;
+  };
+
   const getValidationIcon = (systemId: string) => {
     const report = validationReports[systemId];
     if (!report) {
@@ -122,6 +139,8 @@ export default function PublicFeedProviders() {
               <TableCell>Version</TableCell>
               <TableCell>Enabled</TableCell>
               <TableCell>Subscription Status</TableCell>
+              <TableCell>Data Fresh</TableCell>
+              <TableCell>Last Updated</TableCell>
               <TableCell>Validation</TableCell>
             </TableRow>
           </TableHead>
@@ -153,6 +172,14 @@ export default function PublicFeedProviders() {
                     size="small"
                   />
                 </TableCell>
+                <TableCell>
+                  <Chip
+                    label={provider.dataFresh ? 'Fresh' : 'Stale'}
+                    color={provider.dataFresh ? 'success' : 'default'}
+                    size="small"
+                  />
+                </TableCell>
+                <TableCell>{formatLastUpdated(provider.lastUpdated)}</TableCell>
                 <TableCell>
                   <IconButton
                     size="small"

--- a/ui/src/types/status.ts
+++ b/ui/src/types/status.ts
@@ -6,6 +6,10 @@ export interface PublicFeedProviderStatus {
   version: string;
   enabled: boolean;
   subscriptionStatus: SubscriptionStatus;
+  /** Whether the system is currently receiving fresh data (realtime feed not overdue). */
+  dataFresh: boolean;
+  /** Epoch seconds of the most recent realtime feed update, or null if none cached. */
+  lastUpdated: number | null;
 }
 
 export type SubscriptionStatus = 'STARTED' | 'STARTING' | 'STOPPED' | 'STOPPING';


### PR DESCRIPTION
## Problem

The public status endpoint (`/status/feed-providers`) reported actively-running feeds as `STOPPED`. Confirmed in prod: 32 STARTED / 44 enabled-STOPPED, while the STOPPED feeds (boltoslo, oslobysykkel, getaround*, ryde*, dott*) were all serving data minutes old.

Root cause: subscription status was a **write-once Redis flag**, defaulted to `STOPPED` when absent, that the restart path removed and a leader restart wiped — fully decoupled from whether the feed was actually being polled. Investigation ruled out multi-leader, Redis eviction (`evicted_keys=0`), and read-replica divergence; the raw leader map literally held only 33 entries with the broken feeds absent.

## Changes

**1. Durable subscription desired-state** (the "survives leader restart" requirement)
- `SubscriptionRegistry.clearInMemory()` preserves the durable Redis status on leader (re)start; `start()`/`stop()` no longer wipe it.
- `SubscriptionRegistry.isStopped()` + `FeedUpdater.shouldSubscribe()` — `createSubscriptions` skips an `enabled` provider whose subscription is explicitly `STOPPED`, so a stopped feed is **not auto-resubscribed by a new leader**.

**2. Restart/stop divergence fix**
- `restartSubscription` removes only the in-memory id (`removeSubscriptionId`), never HDEL'ing the durable status → never momentarily absent.
- Setup failures keep `STARTING`; new `maybeRetrySubscription` guards the 60s retry against reviving stopped feeds or creating duplicate pollers.

**3. Report data freshness separately**
- New `FeedFreshnessService` (overdue logic extracted from `MetricUpdater`, which now delegates) exposes `isLive` / `lastUpdated`.
- `PublicFeedProviderStatus` gains `dataFresh` (boolean) + `lastUpdated` (epoch seconds). `subscriptionStatus` = durable intent; `dataFresh` = actual data flow.
- Public status UI shows a Fresh/Stale chip and a relative "Last Updated" column.

## Behaviour

| enabled | desired-state | fresh data | `subscriptionStatus` | `dataFresh` |
|---|---|---|---|---|
| true | STARTED | yes | STARTED | true |
| true | STARTED | no (upstream dead) | STARTED | false |
| true | STOPPED | — | STOPPED | false |
| false | — | — | STOPPED | false |

## Rollout

The DTO change is additive (backward-compatible). On first deploy the currently-broken feeds self-correct: they are *absent* in the durable map → treated as "should start" → resubscribed and persisted as `STARTED`; a genuinely-stopped feed stays stopped.

## Testing

- Java: full suite **319 tests, 0 failures/errors**; `mvn prettier:check` clean. New/extended: `FeedFreshnessServiceTest`, `PublicFeedProviderStatusMapperTest`, `SubscriptionRegistryTest`, `FeedUpdaterSubscriptionTest`, `MetricsUpdaterTest`.
- UI: `tsc --noEmit`, `eslint`, `vite build`, prettier — all clean.