### PR TITLE
Fix flaky createSubscriptions strict-stubbing mismatch

### DIFF
--- a/src/test/java/org/entur/lamassu/leader/FeedUpdaterSubscriptionTest.java
+++ b/src/test/java/org/entur/lamassu/leader/FeedUpdaterSubscriptionTest.java
@@ -315,7 +315,13 @@ class FeedUpdaterSubscriptionTest {
     stopped.setEnabled(true);
 
     when(feedProviderConfig.getProviders()).thenReturn(List.of(started, stopped));
-    when(subscriptionStatusCache.getStatus("stopped-system"))
+    // createSubscriptions() filters via shouldSubscribe(), which calls getStatus()
+    // for every provider. Only "stopped-system" is stubbed here; the unstubbed
+    // "started-system" call returns null (not STOPPED) and must not trip strict
+    // stubbing, so the stub is lenient. The parallelStream() in createSubscriptions
+    // otherwise makes the strict-stubbing mismatch surface nondeterministically.
+    lenient()
+      .when(subscriptionStatusCache.getStatus("stopped-system"))
       .thenReturn(SubscriptionStatus.STOPPED);
 
     feedUpdater.createSubscriptions();


### PR DESCRIPTION
## Problem

`FeedUpdaterSubscriptionTest.createSubscriptions_skipsStoppedProviders` fails intermittently in CI with a Mockito `PotentialStubbingProblem` (e.g. observed on the CI run for #884, unrelated to that PR's npm bump).

## Root cause

`FeedUpdater.createSubscriptions()` filters providers via `parallelStream().filter(this::shouldSubscribe)`. `shouldSubscribe` → `SubscriptionRegistry.isStopped()` calls `subscriptionStatusCache.getStatus(systemId)` for **every** provider. The test only stubbed `getStatus("stopped-system")`, so the legitimate `getStatus("started-system")` call tripped strict stubbing. The `parallelStream()` concurrency made the mismatch surface nondeterministically.

## Fix

Make the `stopped-system` stub `lenient()`. The unstubbed `started-system` lookup returns `null` (not `STOPPED`), which is the intended behaviour — it must not trip strict stubbing.

Verified passing across repeated local runs.