### PR TITLE
chore(ui): fix prettier formatting in FeedProviderForm

### DIFF
--- a/ui/src/components/admin/FeedProviderForm.tsx
+++ b/ui/src/components/admin/FeedProviderForm.tsx
@@ -71,8 +71,7 @@ export function FeedProviderForm({
     (field: keyof FeedProvider) =>
     (
       event:
-        | React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
-        | { target: { value: unknown } }
+        React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement> | { target: { value: unknown } }
     ) => {
       const value = event.target.value;
       setFormData(prev => ({


### PR DESCRIPTION
## What

Runs `prettier --write` on `ui/src/components/admin/FeedProviderForm.tsx`. Formatting-only, no behavioral change.

## Why

The `ui` CI job (`npm run check` → `prettier . --check`) has been **failing on master**. This surfaced on an unrelated PR (#892) whose `ui` job was red for a file it never touched.

### Why it wasn't caught before

- The prettier gate (`npm run check`) was added in `faabdab8` (2025-10-15).
- `FeedProviderForm.tsx` was introduced **unformatted** later, via #818 (`feature/status-provider-ui`, 2025-11-13).
- It merged anyway because **`ui` is not a required status check** on `master` — branch protection only requires `tests`. So a red `ui` job does not block merges, and the prettier gate is effectively advisory.

## Follow-up (not in this PR)

Consider making `ui` a required status check on `master` so formatting regressions actually block merges. Flagging rather than changing branch protection here.